### PR TITLE
Drop pygobject dependency

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -89,6 +89,7 @@ jobs:
                   patch -p1 < ../0001-Support-custom-platform-tag.patch
                   patch -p1 < ../0002-Revert-Python-dependencies.patch
                   patch -p1 < ../0003-Use-data-as-platform-storage-location.patch
+                  patch -p1 < ../0004-Drop-pygobject-dependency.patch
             - name: Bootstrap
               run: scripts/build/gn_bootstrap.sh
             - name: Setup Build, Run Build and Run Tests

--- a/0001-Support-custom-platform-tag.patch
+++ b/0001-Support-custom-platform-tag.patch
@@ -1,5 +1,5 @@
 From 60ee727300ce3685624cbece545f81d3c6350a8b Mon Sep 17 00:00:00 2001
-Message-Id: <60ee727300ce3685624cbece545f81d3c6350a8b.1673964289.git.stefan@agner.ch>
+Message-Id: <60ee727300ce3685624cbece545f81d3c6350a8b.1676381983.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Tue, 22 Nov 2022 10:51:17 +0100
 Subject: [PATCH] Support custom platform tag
@@ -47,5 +47,5 @@ index a0381f096..8da839169 100644
    tags = "cp37-abi3-" + py_platform_tag
  
 -- 
-2.39.0
+2.39.1
 

--- a/0002-Revert-Python-dependencies.patch
+++ b/0002-Revert-Python-dependencies.patch
@@ -1,7 +1,7 @@
 From 476de3f0ff61b91d2547269ee62bc8c2a76a7441 Mon Sep 17 00:00:00 2001
-Message-Id: <476de3f0ff61b91d2547269ee62bc8c2a76a7441.1673964289.git.stefan@agner.ch>
-In-Reply-To: <60ee727300ce3685624cbece545f81d3c6350a8b.1673964289.git.stefan@agner.ch>
-References: <60ee727300ce3685624cbece545f81d3c6350a8b.1673964289.git.stefan@agner.ch>
+Message-Id: <476de3f0ff61b91d2547269ee62bc8c2a76a7441.1676381983.git.stefan@agner.ch>
+In-Reply-To: <60ee727300ce3685624cbece545f81d3c6350a8b.1676381983.git.stefan@agner.ch>
+References: <60ee727300ce3685624cbece545f81d3c6350a8b.1676381983.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Mon, 19 Sep 2022 23:05:51 +0200
 Subject: [PATCH] Revert Python dependencies
@@ -28,5 +28,5 @@ index 8da839169..8c913d1f9 100644
  
    if (current_os == "mac") {
 -- 
-2.39.0
+2.39.1
 

--- a/0003-Use-data-as-platform-storage-location.patch
+++ b/0003-Use-data-as-platform-storage-location.patch
@@ -1,7 +1,7 @@
 From 74754ce606449449286a86227ab2161befe09a06 Mon Sep 17 00:00:00 2001
-Message-Id: <74754ce606449449286a86227ab2161befe09a06.1673964289.git.stefan@agner.ch>
-In-Reply-To: <60ee727300ce3685624cbece545f81d3c6350a8b.1673964289.git.stefan@agner.ch>
-References: <60ee727300ce3685624cbece545f81d3c6350a8b.1673964289.git.stefan@agner.ch>
+Message-Id: <74754ce606449449286a86227ab2161befe09a06.1676381983.git.stefan@agner.ch>
+In-Reply-To: <60ee727300ce3685624cbece545f81d3c6350a8b.1676381983.git.stefan@agner.ch>
+References: <60ee727300ce3685624cbece545f81d3c6350a8b.1676381983.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Fri, 27 May 2022 16:38:14 +0200
 Subject: [PATCH] Use /data as platform storage location
@@ -28,5 +28,5 @@ index 69d028925..af1019350 100644
      "../DeviceSafeQueue.cpp",
      "../DeviceSafeQueue.h",
 -- 
-2.39.0
+2.39.1
 

--- a/0004-Drop-pygobject-dependency.patch
+++ b/0004-Drop-pygobject-dependency.patch
@@ -1,0 +1,43 @@
+From 6aa8bceb2fbe34e746c9cf78b9857ab1434236f1 Mon Sep 17 00:00:00 2001
+Message-Id: <6aa8bceb2fbe34e746c9cf78b9857ab1434236f1.1676381983.git.stefan@agner.ch>
+In-Reply-To: <60ee727300ce3685624cbece545f81d3c6350a8b.1676381983.git.stefan@agner.ch>
+References: <60ee727300ce3685624cbece545f81d3c6350a8b.1676381983.git.stefan@agner.ch>
+From: Stefan Agner <stefan@agner.ch>
+Date: Tue, 14 Feb 2023 14:37:54 +0100
+Subject: [PATCH] Drop pygobject dependency
+
+---
+ src/controller/python/BUILD.gn                  | 2 --
+ src/pybindings/pycontroller/build-chip-wheel.py | 3 ---
+ 2 files changed, 5 deletions(-)
+
+diff --git a/src/controller/python/BUILD.gn b/src/controller/python/BUILD.gn
+index 8c913d1f9..8f0a40a1f 100644
+--- a/src/controller/python/BUILD.gn
++++ b/src/controller/python/BUILD.gn
+@@ -312,8 +312,6 @@ chip_python_wheel_action("chip-core") {
+ 
+   if (current_os == "mac") {
+     py_package_reqs += [ "pyobjc-framework-corebluetooth" ]
+-  } else if (current_os == "linux") {
+-    py_package_reqs += [ "pygobject" ]
+   }
+ 
+   if (current_cpu == "x64") {
+diff --git a/src/pybindings/pycontroller/build-chip-wheel.py b/src/pybindings/pycontroller/build-chip-wheel.py
+index d1de59224..8d913b43d 100644
+--- a/src/pybindings/pycontroller/build-chip-wheel.py
++++ b/src/pybindings/pycontroller/build-chip-wheel.py
+@@ -122,9 +122,6 @@ try:
+     if platform.system() == 'Darwin':
+         requiredPackages.append('pyobjc-framework-corebluetooth')
+ 
+-    if platform.system() == 'Linux':
+-        requiredPackages.append('pygobject')
+-
+     #
+     # Build the chip package...
+     #
+-- 
+2.39.1
+


### PR DESCRIPTION
It is no longer required since for BlueZ communication the C++ API is used.