### PR TITLE
Add patch to create lookup dicts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -91,6 +91,7 @@ jobs:
                   patch -p1 < ../0003-Use-data-as-platform-storage-location.patch
                   patch -p1 < ../0004-Drop-pygobject-dependency.patch
                   patch -p1 < ../0005-Fix-Objects.py-for-Python-3.11-compatibility.patch
+                  patch -p1 < ../0006-Add-lookup-dicts-for-clusters-and-attributes.patch
             - name: Bootstrap
               run: scripts/build/gn_bootstrap.sh
             - name: Setup Build, Run Build and Run Tests

--- a/0006-Add-lookup-dicts-for-clusters-and-attributes.patch
+++ b/0006-Add-lookup-dicts-for-clusters-and-attributes.patch
@@ -1,0 +1,57 @@
+From ad37e367f4989efb5cd8668e3a086101385d2c2a Mon Sep 17 00:00:00 2001
+From: Marcel van der Veldt <m.vanderveldt@outlook.com>
+Date: Mon, 20 Feb 2023 19:17:39 +0100
+Subject: [PATCH] Add lookup dicts for clusters and attributes
+
+---
+ .../python/chip/clusters/ClusterObjects.py    | 20 +++++++++++++++++++
+ 1 file changed, 20 insertions(+)
+
+diff --git a/src/controller/python/chip/clusters/ClusterObjects.py b/src/controller/python/chip/clusters/ClusterObjects.py
+index c3af537da..2d3a73a10 100644
+--- a/src/controller/python/chip/clusters/ClusterObjects.py
++++ b/src/controller/python/chip/clusters/ClusterObjects.py
+@@ -217,6 +217,10 @@ class ClusterCommand(ClusterObject):
+     def must_use_timed_invoke(cls) -> bool:
+         return False
+ 
++# The below dictionaries will be filled dynamically
++# and are used for quick lookup/mapping from cluster/attribute id to the correct class
++ALL_CLUSTERS = {}
++ALL_ATTRIBUTES = {}
+ 
+ class Cluster(ClusterObject):
+     '''
+@@ -227,6 +231,13 @@ class Cluster(ClusterObject):
+     especially the TLV decoding logic. Also ThreadNetworkDiagnostics has an attribute with the same name so we
+     picked data_version as its name.
+     '''
++
++    def __init_subclass__(cls, *args, **kwargs) -> None:
++        """Register a subclass."""
++        super().__init_subclass__(*args, **kwargs)
++        # register this cluster in the ALL_CLUSTERS dict for quick lookups
++        ALL_CLUSTERS[cls.id] = cls
++
+     @property
+     def data_version(self) -> int:
+         return self._data_version
+@@ -253,6 +264,15 @@ class ClusterAttributeDescriptor:
+ 
+     The implementation of this functions is quite tricky, it will create a cluster object on-the-fly, and use it for actual encode / decode routine to save lines of code.
+     '''
++
++    def __init_subclass__(cls, *args, **kwargs) -> None:
++        """Register a subclass."""
++        super().__init_subclass__(*args, **kwargs)
++        if cls.cluster_id not in ALL_ATTRIBUTES:
++            ALL_ATTRIBUTES[cls.cluster_id] = {}
++        # register this clusterattribute in the ALL_ATTRIBUTES dict for quick lookups
++        ALL_ATTRIBUTES[cls.cluster_id][cls.attribute_id] = cls
++
+     @classmethod
+     def ToTLV(cls, tag: Union[int, None], value):
+         writer = tlv.TLVWriter()
+-- 
+2.37.0 (Apple Git-136)
+


### PR DESCRIPTION
Patch ClusterObjects.py to dynamically create 2 lookups dicts we will use to quickly map the cluster/atribute id to the correct class. We will also PR this upstream but we need this change now.