### PR TITLE
Add patch to update cached attributes incrementally

### DIFF
--- a/0008-python-update-cached-attributes-incrementally.patch
+++ b/0008-python-update-cached-attributes-incrementally.patch
@@ -1,7 +1,7 @@
-From 4852cc8d7e29bc7a7dcb951548837ab11099f71b Mon Sep 17 00:00:00 2001
-Message-Id: <4852cc8d7e29bc7a7dcb951548837ab11099f71b.1684933865.git.stefan@agner.ch>
-In-Reply-To: <c46f6cb84fb189da723a9932a5195a553762e2b6.1684933865.git.stefan@agner.ch>
-References: <c46f6cb84fb189da723a9932a5195a553762e2b6.1684933865.git.stefan@agner.ch>
+From 375188d7dfa82d7f49f72fbc05cc0904340d732d Mon Sep 17 00:00:00 2001
+Message-Id: <375188d7dfa82d7f49f72fbc05cc0904340d732d.1684940532.git.stefan@agner.ch>
+In-Reply-To: <c46f6cb84fb189da723a9932a5195a553762e2b6.1684940532.git.stefan@agner.ch>
+References: <c46f6cb84fb189da723a9932a5195a553762e2b6.1684940532.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Wed, 24 May 2023 01:02:48 +0200
 Subject: [PATCH] [python] update cached attributes incrementally
@@ -14,7 +14,7 @@ Obviously, this is significantly faster, especially for small updates.
  1 file changed, 53 insertions(+), 48 deletions(-)
 
 diff --git a/src/controller/python/chip/clusters/Attribute.py b/src/controller/python/chip/clusters/Attribute.py
-index 3660d31234..633fd7ab81 100644
+index 3660d31234..06b57384ed 100644
 --- a/src/controller/python/chip/clusters/Attribute.py
 +++ b/src/controller/python/chip/clusters/Attribute.py
 @@ -383,7 +383,7 @@ class AttributeCache:
@@ -52,7 +52,7 @@ index 3660d31234..633fd7ab81 100644
 +
 +            clusterType = _ClusterIndex[cluster]
 +
-+            if (clusterType not in endpointCache):
++            if clusterType not in endpointCache:
 +                endpointCache[clusterType] = {}
 +
 +            clusterCache = endpointCache[clusterType]

--- a/0008-python-update-cached-attributes-incrementally.patch
+++ b/0008-python-update-cached-attributes-incrementally.patch
@@ -1,0 +1,160 @@
+From 4852cc8d7e29bc7a7dcb951548837ab11099f71b Mon Sep 17 00:00:00 2001
+Message-Id: <4852cc8d7e29bc7a7dcb951548837ab11099f71b.1684933865.git.stefan@agner.ch>
+In-Reply-To: <c46f6cb84fb189da723a9932a5195a553762e2b6.1684933865.git.stefan@agner.ch>
+References: <c46f6cb84fb189da723a9932a5195a553762e2b6.1684933865.git.stefan@agner.ch>
+From: Stefan Agner <stefan@agner.ch>
+Date: Wed, 24 May 2023 01:02:48 +0200
+Subject: [PATCH] [python] update cached attributes incrementally
+
+Instead of rebuilding the cache from scratch on every report, just
+update the Endpoint/Cluster/Attributes which actually changed.
+Obviously, this is significantly faster, especially for small updates.
+---
+ .../python/chip/clusters/Attribute.py         | 101 +++++++++---------
+ 1 file changed, 53 insertions(+), 48 deletions(-)
+
+diff --git a/src/controller/python/chip/clusters/Attribute.py b/src/controller/python/chip/clusters/Attribute.py
+index 3660d31234..633fd7ab81 100644
+--- a/src/controller/python/chip/clusters/Attribute.py
++++ b/src/controller/python/chip/clusters/Attribute.py
+@@ -383,7 +383,7 @@ class AttributeCache:
+ 
+         clusterCache[path.AttributeId] = data
+ 
+-    def UpdateCachedData(self):
++    def UpdateCachedData(self, changedPathSet: set[AttributePath]):
+         ''' This converts the raw TLV data into a cluster object format.
+ 
+             Two formats are available:
+@@ -401,68 +401,73 @@ class AttributeCache:
+         tlvCache = self.attributeTLVCache
+         attributeCache = self.attributeCache
+ 
+-        for endpoint in tlvCache:
++        for attributePath in changedPathSet:
++            endpoint = attributePath.EndpointId
++
+             if (endpoint not in attributeCache):
+                 attributeCache[endpoint] = {}
+ 
+             endpointCache = attributeCache[endpoint]
+ 
+-            for cluster in tlvCache[endpoint]:
+-                if cluster not in _ClusterIndex:
++            cluster = attributePath.ClusterId
++
++            if cluster not in _ClusterIndex:
++                #
++                # #22599 tracks dealing with unknown clusters more
++                # gracefully so that clients can still access this data.
++                #
++                continue
++
++            clusterType = _ClusterIndex[cluster]
++
++            if (clusterType not in endpointCache):
++                endpointCache[clusterType] = {}
++
++            clusterCache = endpointCache[clusterType]
++            clusterDataVersion = self.versionList.get(
++                endpoint, {}).get(cluster, None)
++
++            if (self.returnClusterObject):
++                try:
++                    # Since the TLV data is already organized by attribute tags, we can trivially convert to a cluster object representation.
++                    endpointCache[clusterType] = clusterType.FromDict(
++                        data=clusterType.descriptor.TagDictToLabelDict([], tlvCache[endpoint][cluster]))
++                    endpointCache[clusterType].SetDataVersion(
++                        clusterDataVersion)
++                except Exception as ex:
++                    decodedValue = ValueDecodeFailure(
++                        tlvCache[endpoint][cluster], ex)
++                    endpointCache[clusterType] = decodedValue
++            else:
++                clusterCache[DataVersion] = clusterDataVersion
++
++                attribute = attributePath.AttributeId
++
++                value = tlvCache[endpoint][cluster][attribute]
++
++                if (cluster, attribute) not in _AttributeIndex:
+                     #
+                     # #22599 tracks dealing with unknown clusters more
+                     # gracefully so that clients can still access this data.
+                     #
+                     continue
+ 
+-                clusterType = _ClusterIndex[cluster]
+-
+-                if (clusterType not in endpointCache):
+-                    endpointCache[clusterType] = {}
++                attributeType = _AttributeIndex[(
++                    cluster, attribute)][0]
+ 
+-                clusterCache = endpointCache[clusterType]
+-                clusterDataVersion = self.versionList.get(
+-                    endpoint, {}).get(cluster, None)
++                if (attributeType not in clusterCache):
++                    clusterCache[attributeType] = {}
+ 
+-                if (self.returnClusterObject):
++                if isinstance(value, ValueDecodeFailure):
++                    clusterCache[attributeType] = value
++                else:
+                     try:
+-                        # Since the TLV data is already organized by attribute tags, we can trivially convert to a cluster object representation.
+-                        endpointCache[clusterType] = clusterType.FromDict(
+-                            data=clusterType.descriptor.TagDictToLabelDict([], tlvCache[endpoint][cluster]))
+-                        endpointCache[clusterType].SetDataVersion(
+-                            clusterDataVersion)
++                        decodedValue = attributeType.FromTagDictOrRawValue(
++                            tlvCache[endpoint][cluster][attribute])
+                     except Exception as ex:
+-                        decodedValue = ValueDecodeFailure(
+-                            tlvCache[endpoint][cluster], ex)
+-                        endpointCache[clusterType] = decodedValue
+-                else:
+-                    clusterCache[DataVersion] = clusterDataVersion
+-                    for attribute in tlvCache[endpoint][cluster]:
+-                        value = tlvCache[endpoint][cluster][attribute]
+-
+-                        if (cluster, attribute) not in _AttributeIndex:
+-                            #
+-                            # #22599 tracks dealing with unknown clusters more
+-                            # gracefully so that clients can still access this data.
+-                            #
+-                            continue
+-
+-                        attributeType = _AttributeIndex[(
+-                            cluster, attribute)][0]
+-
+-                        if (attributeType not in clusterCache):
+-                            clusterCache[attributeType] = {}
+-
+-                        if (type(value) is ValueDecodeFailure):
+-                            clusterCache[attributeType] = value
+-                        else:
+-                            try:
+-                                decodedValue = attributeType.FromTagDictOrRawValue(
+-                                    tlvCache[endpoint][cluster][attribute])
+-                            except Exception as ex:
+-                                decodedValue = ValueDecodeFailure(value, ex)
++                        decodedValue = ValueDecodeFailure(value, ex)
+ 
+-                            clusterCache[attributeType] = decodedValue
++                    clusterCache[attributeType] = decodedValue
+ 
+ 
+ class SubscriptionTransaction:
+@@ -741,7 +746,7 @@ class AsyncReadTransaction:
+         pass
+ 
+     def _handleReportEnd(self):
+-        self._cache.UpdateCachedData()
++        self._cache.UpdateCachedData(self._changedPathSet)
+ 
+         if (self._subscription_handler is not None):
+             for change in self._changedPathSet:
+-- 
+2.40.1
+


### PR DESCRIPTION
This changes how the Attribute Cache is updated. Now only attributes which actually changed get updated. The initial update still takes long as the full cache is built, but successive updates are much faster This significantly improves performance of a single attribute update on my x86-64 machine from ~1s down to 20ms.