### PR TITLE
Use libnl address selection mode for minimal mDNS

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -126,6 +126,7 @@ jobs:
                                                   chip_config_memory_debug_checks=false \
                                                   chip_config_memory_debug_dmalloc=false \
                                                   chip_mdns=\"minimal\" \
+                                                  chip_minmdns_default_policy=\"libnl\" \
                                                   chip_python_version=\"${{ needs.build_prepare.outputs.version }}\"  \
                                                   chip_python_package_prefix=\"home-assistant-chip\" \
                                                   chip_python_platform_tag=\"manylinux_2_31\" \


### PR DESCRIPTION
The libnl address selection mode takes interface and address flags into account, which weeds out temporary addresses (before Duplicate Address Detection/DAD) or deprecated addresses (from old routing advertisements).