### PR TITLE
Make sure the generated version is Python safe

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
                 elif [[ "${version}" =~ (main|dev) ]]; then
                   today="$(date --utc '+%Y-%m-%d')"
                   midnight_timestamp="$(date --utc +%s --date=$today)"
-                  calver_date="$(date --utc --date=$today '+%Y.%-m.dev%d')"
+                  calver_date="$(date --utc --date=$today '+%Y.%-m.dev%-d')"
                   commit_count="$(git rev-list --count --since=$midnight_timestamp HEAD)"
                   commit_count="$(printf "%02d" ${commit_count})"
                   version="${calver_date}${commit_count}"


### PR DESCRIPTION
Currently dev builds have a zero prependet (e.g. dev0102). Python seems to drop that 0 when passing to the build system, leading to a wheel with a version without leading zero (dev101).

Don't use the leading zero to make it a valid Python version from the beginning and avoid unexpected file names later on during the build.