### PR TITLE
Add support for Scope ID/Interface ID in CommissionIP API

### DIFF
--- a/0005-Python-Parse-Interface-ID-from-IP-address-string-as-.patch
+++ b/0005-Python-Parse-Interface-ID-from-IP-address-string-as-.patch
@@ -1,0 +1,54 @@
+From 5b5e383674e78115107c7a95eb563902cd6b6014 Mon Sep 17 00:00:00 2001
+Message-ID: <5b5e383674e78115107c7a95eb563902cd6b6014.1704821887.git.stefan@agner.ch>
+From: Stefan Agner <stefan@agner.ch>
+Date: Tue, 9 Jan 2024 18:35:50 +0100
+Subject: [PATCH] [Python] Parse Interface ID from IP address string as well
+
+Currently, when passing a link-local address with an interface specified
+using the %<interface> notation leads to "CHIP Error 0x0000002F: Invalid
+argument".
+
+Correctly parse the interface ID as well and pass it to the PeerAddress
+object.
+---
+ .../python/ChipDeviceController-ScriptBinding.cpp      | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/src/controller/python/ChipDeviceController-ScriptBinding.cpp b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+index a7732a4836..e3e4de8d88 100644
+--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
++++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+@@ -383,13 +383,14 @@ PyChipError pychip_DeviceController_ConnectIP(chip::Controller::DeviceCommission
+                                               uint32_t setupPINCode, chip::NodeId nodeid)
+ {
+     chip::Inet::IPAddress peerAddr;
++    chip::Inet::InterfaceId ifaceOutput;
+     chip::Transport::PeerAddress addr;
+     chip::RendezvousParameters params = chip::RendezvousParameters().SetSetupPINCode(setupPINCode);
+ 
+-    VerifyOrReturnError(chip::Inet::IPAddress::FromString(peerAddrStr, peerAddr), ToPyChipError(CHIP_ERROR_INVALID_ARGUMENT));
++    VerifyOrReturnError(chip::Inet::IPAddress::FromString(peerAddrStr, peerAddr, ifaceOutput), ToPyChipError(CHIP_ERROR_INVALID_ARGUMENT));
+ 
+     // TODO: IP rendezvous should use TCP connection.
+-    addr.SetTransportType(chip::Transport::Type::kUdp).SetIPAddress(peerAddr);
++    addr.SetTransportType(chip::Transport::Type::kUdp).SetIPAddress(peerAddr).SetInterface(ifaceOutput);
+     params.SetPeerAddress(addr).SetDiscriminator(0);
+ 
+     sPairingDelegate.SetExpectingPairingComplete(true);
+@@ -577,10 +578,11 @@ PyChipError pychip_DeviceController_EstablishPASESessionIP(chip::Controller::Dev
+                                                            uint32_t setupPINCode, chip::NodeId nodeid, uint16_t port)
+ {
+     chip::Inet::IPAddress peerAddr;
++    chip::Inet::InterfaceId ifaceOutput;
+     chip::Transport::PeerAddress addr;
+     RendezvousParameters params = chip::RendezvousParameters().SetSetupPINCode(setupPINCode);
+-    VerifyOrReturnError(chip::Inet::IPAddress::FromString(peerAddrStr, peerAddr), ToPyChipError(CHIP_ERROR_INVALID_ARGUMENT));
+-    addr.SetTransportType(chip::Transport::Type::kUdp).SetIPAddress(peerAddr);
++    VerifyOrReturnError(chip::Inet::IPAddress::FromString(peerAddrStr, peerAddr, ifaceOutput), ToPyChipError(CHIP_ERROR_INVALID_ARGUMENT));
++    addr.SetTransportType(chip::Transport::Type::kUdp).SetIPAddress(peerAddr).SetInterface(ifaceOutput);
+     if (port != 0)
+     {
+         addr.SetPort(port);
+-- 
+2.43.0
+


### PR DESCRIPTION
Support the scope id/interface id using the procent sign as a separator. This allows to process link-local addresses.