### PR TITLE
Add chip_crypto=boringssl flag

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -124,6 +124,7 @@ jobs:
       - name: Setup Build, Run Build and Run Tests
         run: |
           scripts/build/gn_gen.sh --args=" \
+                                          chip_crypto=\"boringssl\"
                                           enable_rtti=true \
                                           enable_pylib=true \
                                           chip_config_memory_debug_checks=false \
@@ -221,6 +222,7 @@ jobs:
       - name: Setup Build, Run Build and Run Tests
         run: |
           scripts/build/gn_gen.sh --args=" \
+                                          chip_crypto=\"boringssl\"
                                           enable_rtti=true \
                                           enable_pylib=true \
                                           chip_config_memory_debug_checks=false \


### PR DESCRIPTION
Fixes #24.

`boringssl` is bundled as part of the repo and built and statically linked into the resulting library, so it should always be linked to the version used by all other matter SDK users.

I think this solution is much preferrable to running EoL openssl.

* [x] I verified this builds on github actions for [x86_64](https://github.com/leonm1/chip-wheels/actions/runs/7952221255/job/21706593163) and [Mac](https://github.com/leonm1/chip-wheels/actions/runs/7952221255/job/21706593214) (I don't have an aarch64 runner to test on).
* [x] I used the built wheels as inputs to python-matter-server on linux x86_64, booted it up, and it works

<details>
<summary>`ldd` of _ChipDeviceCtrl.so before this change</summary>

```
$ ldd /nix/store/l6krf458fh5ny6gn518h22p7jw54431n-python3.11-home-assistant-chip-core-2024.1.0/lib/python3.11/site-packages/chip/_
ChipDeviceCtrl.so                                                                                                                                                                       
ldd: warning: you do not have execution permission for `/nix/store/l6krf458fh5ny6gn518h22p7jw54431n-python3.11-home-assistant-chip-core-2024.1.0/lib/python3.11/site-packages/chip/_Chip
DeviceCtrl.so'                                                                                                                                                                          
        linux-vdso.so.1 (0x00007fff19f97000)                                                                                                                                            
        libpthread.so.0 => /nix/store/cyrrf49i2hm1w7vn2j945ic3rrzgxbqs-glibc-2.38-44/lib/libpthread.so.0 (0x00007f44281e8000)                                                           
        libcrypto.so.1.1 => not found                                                                                                                                                   
        libgio-2.0.so.0 => /nix/store/hbdl12ck2ibhn5zsi8nsfa6v471pf0j6-glib-2.78.4/lib/libgio-2.0.so.0 (0x00007f4426611000)                                                             
        libgobject-2.0.so.0 => /nix/store/hbdl12ck2ibhn5zsi8nsfa6v471pf0j6-glib-2.78.4/lib/libgobject-2.0.so.0 (0x00007f4428187000)                                                     
        libglib-2.0.so.0 => /nix/store/hbdl12ck2ibhn5zsi8nsfa6v471pf0j6-glib-2.78.4/lib/libglib-2.0.so.0 (0x00007f44264c9000)                                                           
        libnl-route-3.so.200 => /nix/store/y4zbahkcx51lc24yfz92q4nzzsy7ps0i-libnl-3.8.0/lib/libnl-route-3.so.200 (0x00007f44280f0000)                                                   
        libnl-3.so.200 => /nix/store/y4zbahkcx51lc24yfz92q4nzzsy7ps0i-libnl-3.8.0/lib/libnl-3.so.200 (0x00007f44264a5000)                                                               
        libstdc++.so.6 => /nix/store/1s98ricsglmfjjqkfnpvywnip5z7gp9q-gcc-13.2.0-lib/lib/libstdc++.so.6 (0x00007f4426200000)                                                            
        libm.so.6 => /nix/store/cyrrf49i2hm1w7vn2j945ic3rrzgxbqs-glibc-2.38-44/lib/libm.so.6 (0x00007f442611e000)                                                                       
        libc.so.6 => /nix/store/cyrrf49i2hm1w7vn2j945ic3rrzgxbqs-glibc-2.38-44/lib/libc.so.6 (0x00007f4425f35000)                                                                       
        /nix/store/cyrrf49i2hm1w7vn2j945ic3rrzgxbqs-glibc-2.38-44/lib64/ld-linux-x86-64.so.2 (0x00007f44281ef000)                                                                       
        libgmodule-2.0.so.0 => /nix/store/hbdl12ck2ibhn5zsi8nsfa6v471pf0j6-glib-2.78.4/lib/libgmodule-2.0.so.0 (0x00007f44280e7000)                                                     
        libz.so.1 => /nix/store/ilr7br1ck7i6wcgfkynwpnjp7n964h38-zlib-1.3.1/lib/libz.so.1 (0x00007f4426487000)                                                                          
        libmount.so.1 => /nix/store/q9snqijfg4v4pjfabspysxszd25w4lcn-util-linux-minimal-2.39.3-lib/lib/libmount.so.1 (0x00007f4425ec5000)                                               
        libselinux.so.1 => /nix/store/b3l48hkyy6l1xrh0r6z3xnh7gmqc1skd-libselinux-3.3/lib/libselinux.so.1 (0x00007f4425e98000)                                                          
        libffi.so.8 => /nix/store/zabxhfpsgkb9c4sb7fy50pn1l1kczzv2-libffi-3.4.4/lib/libffi.so.8 (0x00007f4426476000)                                                                    
        libpcre2-8.so.0 => /nix/store/4qrxl5iq0ncrypfazkbldccxlw71vl3z-pcre2-10.42/lib/libpcre2-8.so.0 (0x00007f4425dfb000)                                                             
        libgcc_s.so.1 => /nix/store/1s98ricsglmfjjqkfnpvywnip5z7gp9q-gcc-13.2.0-lib/lib/libgcc_s.so.1 (0x00007f4425dd6000)                                                              
        libblkid.so.1 => /nix/store/q9snqijfg4v4pjfabspysxszd25w4lcn-util-linux-minimal-2.39.3-lib/lib/libblkid.so.1 (0x00007f4425d7a000)                                               
        libpcre.so.1 => /nix/store/ydq7i9bchp0xhbwv239vlrimbk4h9ja4-pcre-8.45/lib/libpcre.so.1 (0x00007f4425d00000)                                                                     
        libdl.so.2 => /nix/store/cyrrf49i2hm1w7vn2j945ic3rrzgxbqs-glibc-2.38-44/lib/libdl.so.2 (0x00007f44280de000)
```

</details>

<details>
<summary>`ldd` of _ChipDeviceCtrl.so after this change</summary>

```
$ ldd result/lib/python3.11/site-packages/chip/_ChipDeviceCtrl.so 
ldd: warning: you do not have execution permission for `result/lib/python3.11/site-packages/chip/_ChipDeviceCtrl.so'
        linux-vdso.so.1 (0x00007ffea01f6000)
        libpthread.so.0 => /nix/store/cyrrf49i2hm1w7vn2j945ic3rrzgxbqs-glibc-2.38-44/lib/libpthread.so.0 (0x00007fa7a2ca2000)
        libgio-2.0.so.0 => /nix/store/hbdl12ck2ibhn5zsi8nsfa6v471pf0j6-glib-2.78.4/lib/libgio-2.0.so.0 (0x00007fa7a1011000)
        libgobject-2.0.so.0 => /nix/store/hbdl12ck2ibhn5zsi8nsfa6v471pf0j6-glib-2.78.4/lib/libgobject-2.0.so.0 (0x00007fa7a2c41000)
        libglib-2.0.so.0 => /nix/store/hbdl12ck2ibhn5zsi8nsfa6v471pf0j6-glib-2.78.4/lib/libglib-2.0.so.0 (0x00007fa7a0ec9000)
        libnl-route-3.so.200 => /nix/store/y4zbahkcx51lc24yfz92q4nzzsy7ps0i-libnl-3.8.0/lib/libnl-route-3.so.200 (0x00007fa7a0e34000)
        libnl-3.so.200 => /nix/store/y4zbahkcx51lc24yfz92q4nzzsy7ps0i-libnl-3.8.0/lib/libnl-3.so.200 (0x00007fa7a0e10000)
        libstdc++.so.6 => /nix/store/1s98ricsglmfjjqkfnpvywnip5z7gp9q-gcc-13.2.0-lib/lib/libstdc++.so.6 (0x00007fa7a0a00000)
        libm.so.6 => /nix/store/cyrrf49i2hm1w7vn2j945ic3rrzgxbqs-glibc-2.38-44/lib/libm.so.6 (0x00007fa7a0d2e000)
        libgcc_s.so.1 => /nix/store/1s98ricsglmfjjqkfnpvywnip5z7gp9q-gcc-13.2.0-lib/lib/libgcc_s.so.1 (0x00007fa7a0d09000)
        libc.so.6 => /nix/store/cyrrf49i2hm1w7vn2j945ic3rrzgxbqs-glibc-2.38-44/lib/libc.so.6 (0x00007fa7a0817000)
        /nix/store/cyrrf49i2hm1w7vn2j945ic3rrzgxbqs-glibc-2.38-44/lib64/ld-linux-x86-64.so.2 (0x00007fa7a2ca9000)
        libgmodule-2.0.so.0 => /nix/store/hbdl12ck2ibhn5zsi8nsfa6v471pf0j6-glib-2.78.4/lib/libgmodule-2.0.so.0 (0x00007fa7a2c36000)
        libz.so.1 => /nix/store/ilr7br1ck7i6wcgfkynwpnjp7n964h38-zlib-1.3.1/lib/libz.so.1 (0x00007fa7a0ceb000)
        libmount.so.1 => /nix/store/q9snqijfg4v4pjfabspysxszd25w4lcn-util-linux-minimal-2.39.3-lib/lib/libmount.so.1 (0x00007fa7a0c7b000)
        libselinux.so.1 => /nix/store/b3l48hkyy6l1xrh0r6z3xnh7gmqc1skd-libselinux-3.3/lib/libselinux.so.1 (0x00007fa7a07ea000)
        libffi.so.8 => /nix/store/zabxhfpsgkb9c4sb7fy50pn1l1kczzv2-libffi-3.4.4/lib/libffi.so.8 (0x00007fa7a0c6a000)
        libpcre2-8.so.0 => /nix/store/4qrxl5iq0ncrypfazkbldccxlw71vl3z-pcre2-10.42/lib/libpcre2-8.so.0 (0x00007fa7a074d000)
        libblkid.so.1 => /nix/store/q9snqijfg4v4pjfabspysxszd25w4lcn-util-linux-minimal-2.39.3-lib/lib/libblkid.so.1 (0x00007fa7a06f1000)
        libpcre.so.1 => /nix/store/ydq7i9bchp0xhbwv239vlrimbk4h9ja4-pcre-8.45/lib/libpcre.so.1 (0x00007fa7a0677000)
        libdl.so.2 => /nix/store/cyrrf49i2hm1w7vn2j945ic3rrzgxbqs-glibc-2.38-44/lib/libdl.so.2 (0x00007fa7a2c2d000)
```

</details>