### PR TITLE
Upload all wheels from correct path

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -142,7 +142,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: project-chip/out/controller/python/*.whl
+          files: ./connectedhomeip/out/controller/python/*.whl
       - name: Upload wheels to PyPI
         if: startsWith(github.ref, 'refs/tags/')
         env:
@@ -229,7 +229,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: chip-wheels-macosx-${{ matrix.arch.name }}
-          path: project-chip/out/controller/python/*.whl
+          path: ./connectedhomeip/out/controller/python/*.whl
       - name: Upload wheels as release assets
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Upload wheels from the connectedhomeip directory which is now where the Matter SDK lives. This makes sure that wheel builds for macOS are available as well.