### PR TITLE
[Python] Fix Event callback for ARM64 Apple Platform devices

### DIFF
--- a/0001-Python-Fix-OnRead-Event-Attribute-DataCallback-for-A.patch
+++ b/0001-Python-Fix-OnRead-Event-Attribute-DataCallback-for-A.patch
@@ -1,0 +1,54 @@
+From dce7020f3a9e542e6afbc59f131c77210df5f7db Mon Sep 17 00:00:00 2001
+Message-ID: <dce7020f3a9e542e6afbc59f131c77210df5f7db.1714067071.git.stefan@agner.ch>
+From: Stefan Agner <stefan@agner.ch>
+Date: Thu, 25 Apr 2024 15:19:17 +0200
+Subject: [PATCH] [Python] Fix OnRead[Event|Attribute]DataCallback for Arm64
+ Apple Patform devices
+
+On M1/Arm64 macOS systems, the OnReadEventDataCallback often returned
+an invalid status, e.g.:
+ValueError: 16 is not a valid Status
+
+Use size_t consistently to fix this issue.
+---
+ src/controller/python/chip/clusters/attribute.cpp | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/controller/python/chip/clusters/attribute.cpp b/src/controller/python/chip/clusters/attribute.cpp
+index e31f3431b8..b73b4a49b4 100644
+--- a/src/controller/python/chip/clusters/attribute.cpp
++++ b/src/controller/python/chip/clusters/attribute.cpp
+@@ -71,10 +71,10 @@ struct __attribute__((packed)) DataVersionFilter
+ using OnReadAttributeDataCallback       = void (*)(PyObject * appContext, chip::DataVersion version, chip::EndpointId endpointId,
+                                              chip::ClusterId clusterId, chip::AttributeId attributeId,
+                                              std::underlying_type_t<Protocols::InteractionModel::Status> imstatus, uint8_t * data,
+-                                             uint32_t dataLen);
++                                             size_t dataLen);
+ using OnReadEventDataCallback           = void (*)(PyObject * appContext, chip::EndpointId endpointId, chip::ClusterId clusterId,
+                                          chip::EventId eventId, chip::EventNumber eventNumber, uint8_t priority, uint64_t timestamp,
+-                                         uint8_t timestampType, uint8_t * data, uint32_t dataLen,
++                                         uint8_t timestampType, uint8_t * data, size_t dataLen,
+                                          std::underlying_type_t<Protocols::InteractionModel::Status> imstatus);
+ using OnSubscriptionEstablishedCallback = void (*)(PyObject * appContext, SubscriptionId subscriptionId);
+ using OnResubscriptionAttemptedCallback = void (*)(PyObject * appContext, PyChipError aTerminationCause,
+@@ -114,7 +114,7 @@ public:
+         VerifyOrDie(!aPath.IsListItemOperation());
+         size_t bufferLen                  = (apData == nullptr ? 0 : apData->GetRemainingLength() + apData->GetLengthRead());
+         std::unique_ptr<uint8_t[]> buffer = std::unique_ptr<uint8_t[]>(apData == nullptr ? nullptr : new uint8_t[bufferLen]);
+-        uint32_t size                     = 0;
++        size_t size                       = 0;
+         // When the apData is nullptr, means we did not receive a valid attribute data from server, status will be some error
+         // status.
+         if (apData != nullptr)
+@@ -166,7 +166,7 @@ public:
+     void OnEventData(const EventHeader & aEventHeader, TLV::TLVReader * apData, const StatusIB * apStatus) override
+     {
+         uint8_t buffer[CHIP_CONFIG_DEFAULT_UDP_MTU_SIZE];
+-        uint32_t size  = 0;
++        size_t size    = 0;
+         CHIP_ERROR err = CHIP_NO_ERROR;
+         // When the apData is nullptr, means we did not receive a valid event data from server, status will be some error
+         // status.
+-- 
+2.44.0
+


### PR DESCRIPTION
With the latest build, the macOS builds print the following error on various (presumably all) devices which report events:

```
2024-04-23 21:40:35.270 (Dummy-8) ERROR [root] 16 is not a valid Status
Traceback (most recent call last):
  File "/Users/marcelvanderveldt/Workdir/home-assistant-libs/python-matter-server/.venv/lib/python3.12/site-packages/chip/clusters/Attribute.py", line 738, in handleEventData
    Header=header, Data=eventValue, Status=chip.interaction_model.Status(status))
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.1_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/enum.py", line 744, in __call__
    return cls.__new__(cls, value)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.1_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/enum.py", line 1158, in __new__
    raise ve_exc
ValueError: 16 is not a valid Status
```

16 is not a valid status indeed, and cannot originate from the C++ SDK really.

In another, second build, the status was 208 on every callback.

It seems that not all data type work with Python CFFI on Arm64. Use size_t here instead.
