### PR TITLE
Add workflow to bump Matter SDK dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "gitsubmodule"
     directory: "/"
-    allow:
+    ignore:
       - dependency-name: "connectedhomeip"
     schedule:
       interval: "daily"

--- a/.github/workflows/dependency-update.yaml
+++ b/.github/workflows/dependency-update.yaml
@@ -1,0 +1,58 @@
+name: Update Matter SDK submodule
+
+on:
+  schedule:
+    # Runs at 04:30 UTC every day
+    - cron: '30 04 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-connectedhomeip-submodule:
+    runs-on: ubuntu-latest
+    name: Update Matter SDK submodule
+
+    steps:
+      # Checkout the repository
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      # Update submodule (not recursive)
+      - name: Update Submodule
+        id: update-submodule
+        run: |
+          git submodule update --init connectedhomeip/
+          short_hash_before=$(cd connectedhomeip && git rev-parse --short HEAD)
+          echo "short_hash_before=${short_hash_before}" >> $GITHUB_OUTPUT
+          git submodule update --remote connectedhomeip/
+          git add connectedhomeip/
+          if git diff-index --quiet HEAD; then
+              echo "empty=true" >> $GITHUB_OUTPUT
+              exit 0
+          fi
+          short_hash=$(cd connectedhomeip && git rev-parse --short HEAD)
+          echo "short_hash=${short_hash}" >> $GITHUB_OUTPUT
+
+      # Create Pull Request only if there were changes
+      - name: Create Pull Request
+        if: ${{ steps.update-submodule.outputs.empty != true }}
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: Update Matter SDK to `${{steps.update-submodule.outputs.short_hash}}`
+          title: Update Matter SDK to `${{steps.update-submodule.outputs.short_hash}}`
+          body: >
+            Bumps [connectedhomeip](https://github.com/project-chip/connectedhomeip)
+            from `${{ steps.update-submodule.outputs.short_hash_before }}` to
+            `${{ steps.update-submodule.outputs.short_hash }}`.
+
+
+            See full diff at
+            https://github.com/project-chip/connectedhomeip/compare/${{ steps.update-submodule.outputs.short_hash_before }}...${{ steps.update-submodule.outputs.short_hash }}.
+          branch: update-connectedhomeip-submodule-to-${{ steps.update-submodule.outputs.short_hash }}
+          delete-branch: true
+

--- a/.github/workflows/dependency-update.yaml
+++ b/.github/workflows/dependency-update.yaml
@@ -54,5 +54,4 @@ jobs:
             See full diff at
             https://github.com/project-chip/connectedhomeip/compare/${{ steps.update-submodule.outputs.short_hash_before }}...${{ steps.update-submodule.outputs.short_hash }}.
           branch: update-connectedhomeip-submodule-to-${{ steps.update-submodule.outputs.short_hash }}
-          delete-branch: true
 

--- a/.github/workflows/dependency-update.yaml
+++ b/.github/workflows/dependency-update.yaml
@@ -40,11 +40,11 @@ jobs:
 
       # Create Pull Request only if there were changes
       - name: Create Pull Request
-        if: ${{ steps.update-submodule.outputs.empty != true }}
+        if: ${{ steps.update-submodule.outputs.empty != "true" }}
         uses: peter-evans/create-pull-request@v6
         with:
-          commit-message: Update Matter SDK to `${{steps.update-submodule.outputs.short_hash}}`
-          title: Update Matter SDK to `${{steps.update-submodule.outputs.short_hash}}`
+          commit-message: Update Matter SDK to `${{ steps.update-submodule.outputs.short_hash }}`
+          title: Update Matter SDK to `${{ steps.update-submodule.outputs.short_hash }}`
           body: >
             Bumps [connectedhomeip](https://github.com/project-chip/connectedhomeip)
             from `${{ steps.update-submodule.outputs.short_hash_before }}` to

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,3 +3,4 @@
 	url = https://github.com/project-chip/connectedhomeip.git
 	branch = master
 	fetchRecurseSubmodules = false
+	depth = 1


### PR DESCRIPTION
It seems Dependabot can't handle submodules with recursive submodules
well: It fetches them recursively and ultimately runs out of space.

Let's use our own workflow instead.

See also: https://github.com/dependabot/dependabot-core/issues/9376