### PR TITLE
Run builds on PR as well

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,14 @@
 name: CHIP wheels build
 
-on: push
+on:
+  push:
+    branches:
+    - main
+    - release
+  pull_request:
+    branches:
+    - main
+    - release
 
 jobs:
   build_prepare:


### PR DESCRIPTION
PRs created by the bot using the default GitHub token don't trigger on push. By running on PR (to main/release) and on push, we'll still run the full build on push (with secrets access) and just a simple build when a PR is created.