### PR TITLE
Use SSH key to push dependency update to the repository

### DIFF
--- a/.github/workflows/dependency-update.yaml
+++ b/.github/workflows/dependency-update.yaml
@@ -21,6 +21,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: false
+          # Required to push to git repo and trigger push CI run for the PR
+          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       # Update submodule (not recursive)
       - name: Update Submodule


### PR DESCRIPTION
This should trigger a push CI run for this PR. See also: https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#push-using-ssh-deploy-keys