### PR TITLE
Add raw attribute callback support

### DIFF
--- a/0004-Python-Add-raw-attribute-callback.patch
+++ b/0004-Python-Add-raw-attribute-callback.patch
@@ -1,0 +1,105 @@
+From e6058f292a37b6b9a96d94a184c7720bfb6460b1 Mon Sep 17 00:00:00 2001
+From: Stefan Agner <stefan@agner.ch>
+Date: Thu, 23 May 2024 12:48:54 +0200
+Subject: [PATCH] [Python] Add raw attribute callback
+
+Add new subscription callback which uses raw AttributePath as paths
+of changed attributes. This allows to subscribe to custom clusters,
+where no Cluster/Attribute types are part of the Python library.
+
+Also allow to get the raw Python values (in tagged dict format)
+directly from the subscription transaction.
+---
+ .../python/chip/clusters/Attribute.py         | 48 +++++++++++++++----
+ 1 file changed, 38 insertions(+), 10 deletions(-)
+
+diff --git a/src/controller/python/chip/clusters/Attribute.py b/src/controller/python/chip/clusters/Attribute.py
+index 36f5a794f9..16db825c12 100644
+--- a/src/controller/python/chip/clusters/Attribute.py
++++ b/src/controller/python/chip/clusters/Attribute.py
+@@ -431,6 +431,7 @@ class SubscriptionTransaction:
+     def __init__(self, transaction: AsyncReadTransaction, subscriptionId, devCtrl):
+         self._onResubscriptionAttemptedCb = DefaultResubscriptionAttemptedCallback
+         self._onAttributeChangeCb = DefaultAttributeChangeCallback
++        self._onRawAttributeChangeCb = None
+         self._onEventChangeCb = DefaultEventChangeCallback
+         self._onErrorCb = DefaultErrorCallback
+         self._readTransaction = transaction
+@@ -456,6 +457,18 @@ class SubscriptionTransaction:
+         else:
+             return data[path.Path.EndpointId][path.ClusterType][path.AttributeType]
+ 
++    def GetTLVAttributes(self) -> Dict[int, Dict[int, Dict[int, Any]]]:
++        '''Returns the attributes value cache in raw/tag dict value tracking
++        the latest state on the publisher.
++        '''
++        return self._readTransaction._cache.attributeTLVCache
++
++
++    def GetTLVAttribute(self, path: AttributePath) -> bytes:
++        '''Returns a specific attribute given a AttributePath.
++        '''
++        return self._readTransaction._cache.attributeTLVCache[path.EndpointId][path.ClusterId][path.AttributeId]
++
+     def GetEvents(self):
+         return self._readTransaction.GetAllEventValues()
+ 
+@@ -536,8 +549,14 @@ class SubscriptionTransaction:
+         Sets the callback function for the attribute value change event,
+         accepts a Callable accepts an attribute path and the cached data.
+         '''
+-        if callback is not None:
+-            self._onAttributeChangeCb = callback
++        self._onAttributeChangeCb = callback
++
++    def SetRawAttributeUpdateCallback(self, callback: Callable[[AttributePath, SubscriptionTransaction], None]):
++        '''
++        Sets the callback function for raw attribute value change event,
++        accepts a Callable which accepts an attribute path and the cached data.
++        '''
++        self._onRawAttributeChangeCb = callback
+ 
+     def SetEventUpdateCallback(self, callback: Callable[[EventReadResult, SubscriptionTransaction], None]):
+         if callback is not None:
+@@ -555,6 +574,10 @@ class SubscriptionTransaction:
+     def OnAttributeChangeCb(self) -> Callable[[TypedAttributePath, SubscriptionTransaction], None]:
+         return self._onAttributeChangeCb
+ 
++    @property
++    def OnRawAttributeChangeCb(self) -> Callable[[TypedAttributePath, SubscriptionTransaction], None]:
++        return self._onRawAttributeChangeCb
++
+     @property
+     def OnEventChangeCb(self) -> Callable[[EventReadResult, SubscriptionTransaction], None]:
+         return self._onEventChangeCb
+@@ -757,14 +780,19 @@ class AsyncReadTransaction:
+ 
+         if (self._subscription_handler is not None):
+             for change in self._changedPathSet:
+-                try:
+-                    attribute_path = TypedAttributePath(Path=change)
+-                except (KeyError, ValueError) as err:
+-                    # path could not be resolved into a TypedAttributePath
+-                    logging.getLogger(__name__).exception(err)
+-                    continue
+-                self._subscription_handler.OnAttributeChangeCb(
+-                    attribute_path, self._subscription_handler)
++                if self._subscription_handler.OnAttributeChangeCb:
++                    try:
++                        attribute_path = TypedAttributePath(Path=change)
++                    except (KeyError, ValueError) as err:
++                        # path could not be resolved into a TypedAttributePath
++                        logging.getLogger(__name__).exception(err)
++                        continue
++                    self._subscription_handler.OnAttributeChangeCb(
++                        attribute_path, self._subscription_handler)
++
++                if self._subscription_handler.OnRawAttributeChangeCb:
++                    self._subscription_handler.OnRawAttributeChangeCb(
++                        change, self._subscription_handler)
+ 
+             # Clear it out once we've notified of all changes in this transaction.
+         self._changedPathSet = set()
+-- 
+2.45.2
+


### PR DESCRIPTION
This modifies the SDK to add support for untyped attribute update callbacks. This allows to process updates of custom clusters and avoid unnecessary type instantiation server side.

The change in the upstream SDK probably needs a bit more cleanup first.

This adds the same patch to the main branch as added in #68 to the release branch. With this main branch builds can be used by the Python Server again.