### PR TITLE
Upload _ChipDeviceCtrl library map file

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -139,7 +139,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: chip-wheels-linux-${{ matrix.arch.name }}
-          path: ./connectedhomeip/out/controller/python/*.whl
+          path: |
+            ./connectedhomeip/out/controller/python/*.whl
+            ./connectedhomeip/out/obj/src/controller/python/chip/_ChipDeviceCtrl.map
       - name: Upload wheels as release assets
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Upload the _ChipDeviceCtrl.map file to artifacts which can be helpful to get insights what exactly a builds contains.