### PR TITLE
[1.3-branch] Disable host unit test config

### DIFF
--- a/0001-Support-custom-platform-tag.patch
+++ b/0001-Support-custom-platform-tag.patch
@@ -1,4 +1,4 @@
-From bcd84a21c67a681fcaba43118d9d9bb7ed618b55 Mon Sep 17 00:00:00 2001
+From 44cc7593f34d07501c67f06e5f6d7fcf719aae71 Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Tue, 22 Nov 2022 10:51:17 +0100
 Subject: [PATCH] Support custom platform tag

--- a/0002-Use-data-as-platform-storage-location.patch
+++ b/0002-Use-data-as-platform-storage-location.patch
@@ -1,4 +1,4 @@
-From 5c1316070604e8e7ade9b518ad717c63276dd06a Mon Sep 17 00:00:00 2001
+From 703b75caecae8638ea0caeda0c9f4f4a2bdc1819 Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Fri, 27 May 2022 16:38:14 +0200
 Subject: [PATCH] Use /data as platform storage location

--- a/0003-Linux-Increase-number-of-endpoints.patch
+++ b/0003-Linux-Increase-number-of-endpoints.patch
@@ -1,4 +1,4 @@
-From 3bcfcd1d91050868d0153bf7692db3ac844ccc94 Mon Sep 17 00:00:00 2001
+From b5b1aa29c7db8aa4b03f13cd51f9ec4a7b979446 Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 29 Feb 2024 19:07:15 +0100
 Subject: [PATCH] Linux: Increase number of endpoints

--- a/0004-Implement-async-friendly-GetConnectedDevice.patch
+++ b/0004-Implement-async-friendly-GetConnectedDevice.patch
@@ -1,4 +1,4 @@
-From 7ce75765081aeebef5f3adc397dff4db256348eb Mon Sep 17 00:00:00 2001
+From 005112398921c0b0a2cdf9805390311d5b49f4f3 Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Wed, 27 Mar 2024 22:13:19 +0100
 Subject: [PATCH] Implement async friendly GetConnectedDevice

--- a/0005-Fix-OnRead-Event-Attribute-DataCallback-for-Arm64-Ap.patch
+++ b/0005-Fix-OnRead-Event-Attribute-DataCallback-for-Arm64-Ap.patch
@@ -1,4 +1,4 @@
-From 113143a945bbe5663b78b59b05d6b00670d79292 Mon Sep 17 00:00:00 2001
+From 20422009f55822b8dbd0b4cbc2855b756943ce08 Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 25 Apr 2024 15:19:17 +0200
 Subject: [PATCH] Fix OnRead[Event|Attribute]DataCallback for Arm64 Apple

--- a/0006-Add-raw-attribute-callback.patch
+++ b/0006-Add-raw-attribute-callback.patch
@@ -1,4 +1,4 @@
-From 4fe4daf7f165dc007ab6092bee2adef67650d129 Mon Sep 17 00:00:00 2001
+From 749cd076e35127092efa8f680902bebf8967389d Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 23 May 2024 12:48:54 +0200
 Subject: [PATCH] Add raw attribute callback

--- a/0007-Python-Eliminate-ZCLSubscribeAttribute-33337.patch
+++ b/0007-Python-Eliminate-ZCLSubscribeAttribute-33337.patch
@@ -1,4 +1,4 @@
-From ba5d91afca90d186fb78de54f5d71705747b097a Mon Sep 17 00:00:00 2001
+From a1e13f098c1e8a140b016bd10d76b36ebf3d6df2 Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Mon, 13 May 2024 15:16:56 +0200
 Subject: [PATCH] [Python] Eliminate ZCLSubscribeAttribute (#33337)

--- a/0008-Python-Eliminate-ZCLReadAttribute-ZCLSend-33428.patch
+++ b/0008-Python-Eliminate-ZCLReadAttribute-ZCLSend-33428.patch
@@ -1,4 +1,4 @@
-From 393dbaae77c7bf26a869b8498ce5e731ff0b9651 Mon Sep 17 00:00:00 2001
+From 18e6fcae6e2dcaa0a39306c19de0246b6d0a5764 Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 16 May 2024 09:13:00 +0200
 Subject: [PATCH] [Python] Eliminate ZCLReadAttribute/ZCLSend (#33428)

--- a/0009-Python-Create-pairingDelegate-for-each-DeviceControl.patch
+++ b/0009-Python-Create-pairingDelegate-for-each-DeviceControl.patch
@@ -1,4 +1,4 @@
-From 25180ab3236c2af49f6003109e1a2e8769c3ba4b Mon Sep 17 00:00:00 2001
+From e6f0f69d0d61c60cd7ad3b84f59c50794d95797a Mon Sep 17 00:00:00 2001
 From: "tianfeng.yang" <130436698+tianfeng-yang@users.noreply.github.com>
 Date: Wed, 17 Apr 2024 21:53:13 +0800
 Subject: [PATCH] [Python] Create pairingDelegate for each DeviceController

--- a/0010-Python-Call-SDK-asyncio-friendly-32764.patch
+++ b/0010-Python-Call-SDK-asyncio-friendly-32764.patch
@@ -1,4 +1,4 @@
-From 56b56ee08006d935cb86dd3fb38e96d79c78bb45 Mon Sep 17 00:00:00 2001
+From b079cfb8fabc4927dd59e8913684a2b58fcb4f3c Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 16 May 2024 09:35:25 +0200
 Subject: [PATCH] [Python] Call SDK asyncio friendly (#32764)

--- a/0011-Python-Make-AttributePath-more-pythonic-33571.patch
+++ b/0011-Python-Make-AttributePath-more-pythonic-33571.patch
@@ -1,4 +1,4 @@
-From 518fdbac13ace67cfbd4482286320f4c45ab1b05 Mon Sep 17 00:00:00 2001
+From 34be5d25e6038dd22a1e80fa10b548065b6e6215 Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Fri, 24 May 2024 10:39:41 +0200
 Subject: [PATCH] [Python] Make AttributePath more pythonic (#33571)

--- a/0012-Python-Drop-chip-device-ctrl-33488.patch
+++ b/0012-Python-Drop-chip-device-ctrl-33488.patch
@@ -1,4 +1,4 @@
-From 9be9b5e5f8b7988c71b178ffc24c76590c8f0f88 Mon Sep 17 00:00:00 2001
+From c6838582c226796198993741aaa8cd1a1022fed3 Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Fri, 24 May 2024 16:19:35 +0200
 Subject: [PATCH] [Python] Drop chip-device-ctrl (#33488)

--- a/0013-Python-Remove-obsolete-callback-handling-33665.patch
+++ b/0013-Python-Remove-obsolete-callback-handling-33665.patch
@@ -1,4 +1,4 @@
-From 3997a66e9e436646a4652448bc72309d8afee2bf Mon Sep 17 00:00:00 2001
+From 3297c2f2240ac4b3dcf740a2604e1f22a42799d5 Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 30 May 2024 22:41:35 +0200
 Subject: [PATCH] [Python] Remove obsolete callback handling (#33665)

--- a/0014-Python-Add-automation-level-to-log-defines-33670.patch
+++ b/0014-Python-Add-automation-level-to-log-defines-33670.patch
@@ -1,4 +1,4 @@
-From 0fe7d8b3d9c920ce7dc970097962dca14f9d8f03 Mon Sep 17 00:00:00 2001
+From 235286b7c98474afc9434a3eec0c07157b4c3679 Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Fri, 31 May 2024 15:24:42 +0200
 Subject: [PATCH] [Python] Add "automation" level to log defines (#33670)

--- a/0015-Python-Remove-obsolete-logging-callbacks-33718.patch
+++ b/0015-Python-Remove-obsolete-logging-callbacks-33718.patch
@@ -1,4 +1,4 @@
-From 92dc4417ed88d016d0b21e377d1c04a97e55f34e Mon Sep 17 00:00:00 2001
+From 4111dc126f04bce71a0f712c59cc7294c2fcad5d Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Tue, 4 Jun 2024 07:14:58 +0200
 Subject: [PATCH] [Python] Remove obsolete logging callbacks (#33718)

--- a/0016-Python-Drop-network-lock-33720.patch
+++ b/0016-Python-Drop-network-lock-33720.patch
@@ -1,4 +1,4 @@
-From 025bdb7a1e9b9669ab091b96f9ac0adefe3a53dd Mon Sep 17 00:00:00 2001
+From 155d4471de2c988b5089325bb0e9eb59e93d3c0d Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Wed, 5 Jun 2024 16:06:15 +0200
 Subject: [PATCH] [Python] Drop network lock (#33720)

--- a/0017-Python-Remove-Python-Bluetooth-and-ChipStack-event-l.patch
+++ b/0017-Python-Remove-Python-Bluetooth-and-ChipStack-event-l.patch
@@ -1,4 +1,4 @@
-From a4fb58131d9023ad3a3ec01d44c5ae87946d6b59 Mon Sep 17 00:00:00 2001
+From 1edc2acd9f8faeb481e79154c065c2b85eb87fc8 Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 6 Jun 2024 17:11:34 +0200
 Subject: [PATCH] [Python] Remove Python Bluetooth and ChipStack event loop

--- a/0018-Python-Add-TriggerResubscribeIfScheduled-to-Subscrip.patch
+++ b/0018-Python-Add-TriggerResubscribeIfScheduled-to-Subscrip.patch
@@ -1,4 +1,4 @@
-From 9e3eeeaf21a3a258ea6d068f8ade8c321b7b5563 Mon Sep 17 00:00:00 2001
+From 29e6e6b1c0a6925abc33510297f6f49470bcf016 Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Fri, 7 Jun 2024 15:50:34 +0200
 Subject: [PATCH] [Python] Add TriggerResubscribeIfScheduled to

--- a/0019-Python-Drop-deprecated-discovery-APIs-33882.patch
+++ b/0019-Python-Drop-deprecated-discovery-APIs-33882.patch
@@ -1,4 +1,4 @@
-From 75954f9f6c493726c004f31631c9c7baf30ffff4 Mon Sep 17 00:00:00 2001
+From 08d23c879cd47a9ba2d0675ea04a0abb041a8d9e Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Wed, 12 Jun 2024 19:49:51 +0200
 Subject: [PATCH] [Python] Drop deprecated discovery APIs (#33882)

--- a/0020-Remove-unnecessary-error-log-from-CurrentFabricRemov.patch
+++ b/0020-Remove-unnecessary-error-log-from-CurrentFabricRemov.patch
@@ -1,4 +1,4 @@
-From 92f9e7d0d746087ff4c6b0d86b80f7deba661d5d Mon Sep 17 00:00:00 2001
+From 3734bb27d8de27b957698b54d2a03b88619905fc Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 13 Jun 2024 16:13:56 +0200
 Subject: [PATCH] Remove unnecessary error log from CurrentFabricRemover

--- a/0021-Python-Use-thread-safe-futures-for-concurrent-operat.patch
+++ b/0021-Python-Use-thread-safe-futures-for-concurrent-operat.patch
@@ -1,4 +1,4 @@
-From c50c9fe22beee19242de04ea01fa5eb031506c0b Mon Sep 17 00:00:00 2001
+From 0d035c3060a931a7205e64aafb48bf99c82b8301 Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 13 Jun 2024 16:44:23 +0200
 Subject: [PATCH] [Python] Use thread-safe futures for concurrent operations

--- a/0022-Avoid-errors-when-using-on-network-commissioning-338.patch
+++ b/0022-Avoid-errors-when-using-on-network-commissioning-338.patch
@@ -1,4 +1,4 @@
-From 005887af17aa03eb655cee10871e16ff65ceb34e Mon Sep 17 00:00:00 2001
+From 69daf2756196568bd80cc3debe6c11cc6beaa222 Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 13 Jun 2024 22:29:36 +0200
 Subject: [PATCH] Avoid errors when using on-network commissioning (#33880)

--- a/0023-Add-success-message-on-removing-current-fabric-33914.patch
+++ b/0023-Add-success-message-on-removing-current-fabric-33914.patch
@@ -1,4 +1,4 @@
-From 5ec1d9c49d505d5e462f6c935b7f325cbf632e8f Mon Sep 17 00:00:00 2001
+From 988b3fbd5db017f49fc6dd0151a6906f4e47844e Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Fri, 14 Jun 2024 01:34:21 +0200
 Subject: [PATCH] Add success message on removing current fabric (#33914)

--- a/0024-Python-Drop-unnecessary-null-termination-33915.patch
+++ b/0024-Python-Drop-unnecessary-null-termination-33915.patch
@@ -1,4 +1,4 @@
-From 049c5803b347e520ba4b3653ce623b6543ae05b6 Mon Sep 17 00:00:00 2001
+From e5ecc03b7ae65eda30357af92687b36c23bcf36d Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Fri, 14 Jun 2024 15:43:44 +0200
 Subject: [PATCH] [Python] Drop unnecessary null termination (#33915)

--- a/0025-Fix-python-Wi-Fi-Thread-setup-with-manual-code-33933.patch
+++ b/0025-Fix-python-Wi-Fi-Thread-setup-with-manual-code-33933.patch
@@ -1,4 +1,4 @@
-From 462bd9d6a8a9dcf60ab9f674e41c762c602fd8e0 Mon Sep 17 00:00:00 2001
+From bed8252a3ee1cf41510c470514cc86ae4a3a0bf3 Mon Sep 17 00:00:00 2001
 From: Tennessee Carmel-Veilleux <tennessee.carmelveilleux@gmail.com>
 Date: Fri, 14 Jun 2024 18:52:44 -0400
 Subject: [PATCH] Fix python Wi-Fi/Thread setup with manual code (#33933)

--- a/0026-Python-Store-original-PyChipError-in-ChipStackExcept.patch
+++ b/0026-Python-Store-original-PyChipError-in-ChipStackExcept.patch
@@ -1,4 +1,4 @@
-From d9231b499271843b4501ea84bfa56a5b3ac9a1b5 Mon Sep 17 00:00:00 2001
+From 65334ba37c6187dc1d3cf2f2a49fa57ee086d277 Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Tue, 18 Jun 2024 14:45:11 +0200
 Subject: [PATCH] [Python] Store original PyChipError in ChipStackException

--- a/0027-Python-Make-Commissioning-APIs-more-pythonic-and-con.patch
+++ b/0027-Python-Make-Commissioning-APIs-more-pythonic-and-con.patch
@@ -1,4 +1,4 @@
-From a5a507e055db590fe4965fbfa8b2a3b368368cd0 Mon Sep 17 00:00:00 2001
+From 73f66667b8e34ba483b5131bf0697c1456e53746 Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Tue, 18 Jun 2024 23:16:47 +0200
 Subject: [PATCH] [Python] Make Commissioning APIs more pythonic and consistent

--- a/0028-Python-Reset-chip-error-in-test-commissioner-34001.patch
+++ b/0028-Python-Reset-chip-error-in-test-commissioner-34001.patch
@@ -1,4 +1,4 @@
-From 8cf4a7a4a642fc60bc5716860f63292b316335f1 Mon Sep 17 00:00:00 2001
+From f17afe57391c7346af140fcc8cf7442f6f11f781 Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Wed, 19 Jun 2024 16:26:32 +0200
 Subject: [PATCH] [Python] Reset chip error in test commissioner (#34001)

--- a/0029-Python-Convert-async-API-functions-to-python-asyncio.patch
+++ b/0029-Python-Convert-async-API-functions-to-python-asyncio.patch
@@ -1,4 +1,4 @@
-From b60b4c443d21fe3486e1c4c9c7ab92557fa7dda5 Mon Sep 17 00:00:00 2001
+From a574e6a55ed3fa2dfe14f4f2475b2623f5b10cb0 Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 20 Jun 2024 16:14:52 +0200
 Subject: [PATCH] [Python] Convert async API functions to python asyncio

--- a/0030-Python-Convert-DiscoverCommissionableNodes-to-asynci.patch
+++ b/0030-Python-Convert-DiscoverCommissionableNodes-to-asynci.patch
@@ -1,4 +1,4 @@
-From 47d800809a9979b3162f5f676f308ebd9282c361 Mon Sep 17 00:00:00 2001
+From 0b589b17b4c638afb67e4bd6ed91a0c4fabb619d Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Fri, 21 Jun 2024 14:28:03 +0200
 Subject: [PATCH] [Python] Convert DiscoverCommissionableNodes to asyncio

--- a/0031-Python-Adjust-logging-levels-in-Python-controller-34.patch
+++ b/0031-Python-Adjust-logging-levels-in-Python-controller-34.patch
@@ -1,0 +1,422 @@
+From 67211f2c41779d428a509004f346eb72fc31ecb2 Mon Sep 17 00:00:00 2001
+From: Stefan Agner <stefan@agner.ch>
+Date: Tue, 16 Jul 2024 15:52:08 +0100
+Subject: [PATCH] [Python] Adjust logging levels in Python controller (#34346)
+
+Use global loggers per-module which is more Pythonic and avoids
+unnecessary logger instances. Also use the module name as the logger
+name consistently.
+
+Avoid using the warning level for messages which are really only
+informational. Also lower the log level of storage messages to debug,
+as they are really not that important. Drop some unnecessary logs
+like on every storage commit.
+---
+ .../python/chip/CertificateAuthority.py       |  8 +++--
+ src/controller/python/chip/ChipDeviceCtrl.py  | 33 ++++++++++---------
+ src/controller/python/chip/FabricAdmin.py     | 10 +++---
+ .../python/chip/clusters/Attribute.py         | 19 ++++++-----
+ .../python/chip/storage/__init__.py           | 31 ++++++++---------
+ 5 files changed, 50 insertions(+), 51 deletions(-)
+
+diff --git a/src/controller/python/chip/CertificateAuthority.py b/src/controller/python/chip/CertificateAuthority.py
+index bce921cfb7..0fbfcfdbdb 100644
+--- a/src/controller/python/chip/CertificateAuthority.py
++++ b/src/controller/python/chip/CertificateAuthority.py
+@@ -28,6 +28,8 @@ from chip import ChipStack, FabricAdmin
+ from chip.native import PyChipError
+ from chip.storage import PersistentStorage
+ 
++LOGGER = logging.getLogger(__name__)
++
+ 
+ class CertificateAuthority:
+     '''  This represents an operational Root Certificate Authority (CA) with a root key key pair with associated
+@@ -64,7 +66,7 @@ class CertificateAuthority:
+                 persistentStorage:  An optional reference to a PersistentStorage object. If one is provided, it will pick that over
+                                     the default PersistentStorage object retrieved from the chipStack.
+         '''
+-        self.logger().warning(f"New CertificateAuthority at index {caIndex}")
++        LOGGER.info(f"New CertificateAuthority at index {caIndex}")
+ 
+         self._chipStack = chipStack
+         self._caIndex = caIndex
+@@ -105,7 +107,7 @@ class CertificateAuthority:
+         if (not (self._isActive)):
+             raise RuntimeError("Object isn't active")
+ 
+-        self.logger().warning("Loading fabric admins from storage...")
++        LOGGER.info("Loading fabric admins from storage...")
+ 
+         caList = self._persistentStorage.GetReplKey(key='caList')
+         if (str(self._caIndex) not in caList):
+@@ -244,7 +246,7 @@ class CertificateAuthorityManager:
+         if (not (self._isActive)):
+             raise RuntimeError("Object is not active")
+ 
+-        self.logger().warning("Loading certificate authorities from storage...")
++        LOGGER.info("Loading certificate authorities from storage...")
+ 
+         #
+         # Persist details to storage (read modify write).
+diff --git a/src/controller/python/chip/ChipDeviceCtrl.py b/src/controller/python/chip/ChipDeviceCtrl.py
+index 208385f305..fc387728ce 100644
+--- a/src/controller/python/chip/ChipDeviceCtrl.py
++++ b/src/controller/python/chip/ChipDeviceCtrl.py
+@@ -60,6 +60,8 @@ __all__ = ["ChipDeviceController", "CommissioningParameters"]
+ # Defined in $CHIP_ROOT/src/lib/core/CHIPError.h
+ CHIP_ERROR_TIMEOUT: int = 50
+ 
++LOGGER = logging.getLogger(__name__)
++
+ _DevicePairingDelegate_OnPairingCompleteFunct = CFUNCTYPE(None, PyChipError)
+ _DeviceUnpairingCompleteFunct = CFUNCTYPE(None, c_uint64, PyChipError)
+ _DevicePairingDelegate_OnCommissioningCompleteFunct = CFUNCTYPE(
+@@ -309,15 +311,15 @@ class ChipDeviceControllerBase():
+     def _set_dev_ctrl(self, devCtrl, pairingDelegate):
+         def HandleCommissioningComplete(nodeId: int, err: PyChipError):
+             if err.is_success:
+-                logging.info("Commissioning complete")
++                LOGGER.info("Commissioning complete")
+             else:
+-                logging.warning("Failed to commission: {}".format(err))
++                LOGGER.warning("Failed to commission: {}".format(err))
+ 
+             if self._dmLib.pychip_TestCommissionerUsed():
+                 err = self._dmLib.pychip_GetCompletionError()
+ 
+             if self._commissioning_context.future is None:
+-                logging.exception("HandleCommissioningComplete called unexpectedly")
++                LOGGER.exception("HandleCommissioningComplete called unexpectedly")
+                 return
+ 
+             if err.is_success:
+@@ -331,14 +333,14 @@ class ChipDeviceControllerBase():
+         def HandleOpenWindowComplete(nodeid: int, setupPinCode: int, setupManualCode: str,
+                                      setupQRCode: str, err: PyChipError) -> None:
+             if err.is_success:
+-                logging.info("Open Commissioning Window complete setting nodeid {} pincode to {}".format(nodeid, setupPinCode))
++                LOGGER.info("Open Commissioning Window complete setting nodeid {} pincode to {}".format(nodeid, setupPinCode))
+                 commissioningParameters = CommissioningParameters(
+                     setupPinCode=setupPinCode, setupManualCode=setupManualCode.decode(), setupQRCode=setupQRCode.decode())
+             else:
+-                logging.warning("Failed to open commissioning window: {}".format(err))
++                LOGGER.warning("Failed to open commissioning window: {}".format(err))
+ 
+             if self._open_window_context.future is None:
+-                logging.exception("HandleOpenWindowComplete called unexpectedly")
++                LOGGER.exception("HandleOpenWindowComplete called unexpectedly")
+                 return
+ 
+             if err.is_success:
+@@ -348,12 +350,12 @@ class ChipDeviceControllerBase():
+ 
+         def HandleUnpairDeviceComplete(nodeid: int, err: PyChipError):
+             if err.is_success:
+-                logging.info("Succesfully unpaired device with nodeid {}".format(nodeid))
++                LOGGER.info("Succesfully unpaired device with nodeid {}".format(nodeid))
+             else:
+-                logging.warning("Failed to unpair device: {}".format(err))
++                LOGGER.warning("Failed to unpair device: {}".format(err))
+ 
+             if self._unpair_device_context.future is None:
+-                logging.exception("HandleUnpairDeviceComplete called unexpectedly")
++                LOGGER.exception("HandleUnpairDeviceComplete called unexpectedly")
+                 return
+ 
+             if err.is_success:
+@@ -363,9 +365,9 @@ class ChipDeviceControllerBase():
+ 
+         def HandlePASEEstablishmentComplete(err: PyChipError):
+             if not err.is_success:
+-                logging.warning("Failed to establish secure session to device: {}".format(err))
++                LOGGER.warning("Failed to establish secure session to device: {}".format(err))
+             else:
+-                logging.info("Established secure session with Device")
++                LOGGER.info("Established secure session with Device")
+ 
+             if self._commissioning_context.future is not None:
+                 # During Commissioning, HandlePASEEstablishmentComplete will also be called.
+@@ -375,7 +377,7 @@ class ChipDeviceControllerBase():
+                 return
+ 
+             if self._pase_establishment_context.future is None:
+-                logging.exception("HandlePASEEstablishmentComplete called unexpectedly")
++                LOGGER.exception("HandlePASEEstablishmentComplete called unexpectedly")
+                 return
+ 
+             if err.is_success:
+@@ -794,7 +796,7 @@ class ChipDeviceControllerBase():
+             res = self._ChipStack.Call(lambda: self._dmLib.pychip_GetDeviceBeingCommissioned(
+                 self.devCtrl, nodeid, byref(returnDevice)), timeoutMs)
+             if res.is_success:
+-                logging.info('Using PASE connection')
++                LOGGER.info('Using PASE connection')
+                 return DeviceProxyWrapper(returnDevice)
+ 
+         class DeviceAvailableClosure():
+@@ -840,7 +842,7 @@ class ChipDeviceControllerBase():
+             res = await self._ChipStack.CallAsync(lambda: self._dmLib.pychip_GetDeviceBeingCommissioned(
+                 self.devCtrl, nodeid, byref(returnDevice)), timeoutMs)
+             if res.is_success:
+-                logging.info('Using PASE connection')
++                LOGGER.info('Using PASE connection')
+                 return DeviceProxyWrapper(returnDevice)
+ 
+         eventLoop = asyncio.get_running_loop()
+@@ -1196,7 +1198,6 @@ class ChipDeviceControllerBase():
+             # Wildcard
+             return ClusterAttribute.EventPath()
+         elif not isinstance(pathTuple, tuple):
+-            logging.debug(type(pathTuple))
+             if isinstance(pathTuple, int):
+                 return ClusterAttribute.EventPath(EndpointId=pathTuple)
+             elif issubclass(pathTuple, ClusterObjects.Cluster):
+@@ -1918,7 +1919,7 @@ class ChipDeviceController(ChipDeviceControllerBase):
+ 
+     def NOCChainCallback(self, nocChain):
+         if self._issue_node_chain_context.future is None:
+-            logging.exception("NOCChainCallback while not expecting a callback")
++            LOGGER.exception("NOCChainCallback while not expecting a callback")
+             return
+         self._issue_node_chain_context.future.set_result(nocChain)
+         return
+diff --git a/src/controller/python/chip/FabricAdmin.py b/src/controller/python/chip/FabricAdmin.py
+index fc20327e62..d9e2e35cb2 100644
+--- a/src/controller/python/chip/FabricAdmin.py
++++ b/src/controller/python/chip/FabricAdmin.py
+@@ -25,6 +25,8 @@ from chip import CertificateAuthority, ChipDeviceCtrl
+ from chip.crypto import p256keypair
+ from chip.native import GetLibraryHandle
+ 
++LOGGER = logging.getLogger(__name__)
++
+ 
+ class FabricAdmin:
+     ''' Administers a fabric associated with a unique FabricID under a given CertificateAuthority
+@@ -34,10 +36,6 @@ class FabricAdmin:
+     def _Handle(cls):
+         return GetLibraryHandle()
+ 
+-    @classmethod
+-    def logger(cls):
+-        return logging.getLogger('FabricAdmin')
+-
+     def __init__(self, certificateAuthority: CertificateAuthority.CertificateAuthority, vendorId: int, fabricId: int = 1):
+         ''' Initializes the object.
+ 
+@@ -60,7 +58,7 @@ class FabricAdmin:
+         self._fabricId = fabricId
+         self._certificateAuthority = certificateAuthority
+ 
+-        self.logger().warning(f"New FabricAdmin: FabricId: 0x{self._fabricId:016X}, VendorId = 0x{self.vendorId:04X}")
++        LOGGER.info(f"New FabricAdmin: FabricId: 0x{self._fabricId:016X}, VendorId = 0x{self.vendorId:04X}")
+ 
+         self._isActive = True
+         self._activeControllers = []
+@@ -94,7 +92,7 @@ class FabricAdmin:
+             if (nodeId in nodeIdList):
+                 raise RuntimeError(f"Provided NodeId {nodeId} collides with an existing controller instance!")
+ 
+-        self.logger().warning(
++        LOGGER.info(
+             f"Allocating new controller with CaIndex: {self._certificateAuthority.caIndex}, "
+             f"FabricId: 0x{self._fabricId:016X}, NodeId: 0x{nodeId:016X}, CatTags: {catTags}")
+ 
+diff --git a/src/controller/python/chip/clusters/Attribute.py b/src/controller/python/chip/clusters/Attribute.py
+index 16db825c12..69c64a3ffc 100644
+--- a/src/controller/python/chip/clusters/Attribute.py
++++ b/src/controller/python/chip/clusters/Attribute.py
+@@ -40,6 +40,8 @@ from rich.pretty import pprint
+ 
+ from .ClusterObjects import Cluster, ClusterAttributeDescriptor, ClusterEvent
+ 
++LOGGER = logging.getLogger(__name__)
++
+ 
+ @unique
+ class EventTimestampType(Enum):
+@@ -592,7 +594,7 @@ class SubscriptionTransaction:
+ 
+     def Shutdown(self):
+         if (self._isDone):
+-            print("Subscription was already terminated previously!")
++            LOGGER.warning("Subscription 0x%08x was already terminated previously!", self.subscriptionId)
+             return
+ 
+         handle = chip.native.GetLibraryHandle()
+@@ -698,7 +700,7 @@ class AsyncReadTransaction:
+             self._changedPathSet.add(path)
+ 
+         except Exception as ex:
+-            logging.exception(ex)
++            LOGGER.exception(ex)
+ 
+     def handleEventData(self, header: EventHeader, path: EventPath, data: bytes, status: int):
+         try:
+@@ -716,12 +718,12 @@ class AsyncReadTransaction:
+                     try:
+                         eventValue = eventType.FromTLV(data)
+                     except Exception as ex:
+-                        logging.error(
++                        LOGGER.error(
+                             f"Error convering TLV to Cluster Object for path: Endpoint = {path.EndpointId}/"
+                             f"Cluster = {path.ClusterId}/Event = {path.EventId}")
+-                        logging.error(
++                        LOGGER.error(
+                             f"Failed Cluster Object: {str(eventType)}")
+-                        logging.error(ex)
++                        LOGGER.error(ex)
+                         eventValue = ValueDecodeFailure(
+                             tlvData, ex)
+ 
+@@ -738,7 +740,7 @@ class AsyncReadTransaction:
+                     eventResult, self._subscription_handler)
+ 
+         except Exception as ex:
+-            logging.exception(ex)
++            LOGGER.exception(ex)
+ 
+     def handleError(self, chipError: PyChipError):
+         self._resultError = chipError
+@@ -749,7 +751,6 @@ class AsyncReadTransaction:
+                 self, subscriptionId, self._devCtrl)
+             self._future.set_result(self._subscription_handler)
+         else:
+-            logging.info("Re-subscription succeeded!")
+             if self._subscription_handler._onResubscriptionSucceededCb is not None:
+                 if (self._subscription_handler._onResubscriptionSucceededCb_isAsync):
+                     self._event_loop.create_task(
+@@ -785,7 +786,7 @@ class AsyncReadTransaction:
+                         attribute_path = TypedAttributePath(Path=change)
+                     except (KeyError, ValueError) as err:
+                         # path could not be resolved into a TypedAttributePath
+-                        logging.getLogger(__name__).exception(err)
++                        LOGGER.exception(err)
+                         continue
+                     self._subscription_handler.OnAttributeChangeCb(
+                         attribute_path, self._subscription_handler)
+@@ -844,7 +845,7 @@ class AsyncWriteTransaction:
+             imStatus = chip.interaction_model.Status(status)
+             self._resultData.append(AttributeWriteResult(Path=path, Status=imStatus))
+         except ValueError as ex:
+-            logging.exception(ex)
++            LOGGER.exception(ex)
+ 
+     def handleError(self, chipError: PyChipError):
+         self._resultError = chipError
+diff --git a/src/controller/python/chip/storage/__init__.py b/src/controller/python/chip/storage/__init__.py
+index 385efca6be..20432dcd01 100644
+--- a/src/controller/python/chip/storage/__init__.py
++++ b/src/controller/python/chip/storage/__init__.py
+@@ -29,6 +29,8 @@ from typing import Dict
+ import chip.exceptions
+ import chip.native
+ 
++LOGGER = logging.getLogger(__name__)
++
+ _SyncSetKeyValueCbFunct = CFUNCTYPE(
+     None, py_object, c_char_p, POINTER(c_char),  c_uint16)
+ _SyncGetKeyValueCbFunct = CFUNCTYPE(
+@@ -91,9 +93,6 @@ class PersistentStorage:
+ 
+         Object must be resident before the Matter stack starts up and last past its shutdown.
+     '''
+-    @classmethod
+-    def logger(cls):
+-        return logging.getLogger('PersistentStorage')
+ 
+     def __init__(self, path: str = None, jsonData: Dict = None):
+         ''' Initializes the object with either a path to a JSON file that contains the configuration OR
+@@ -109,9 +108,9 @@ class PersistentStorage:
+             raise ValueError("Can't provide both a valid path and jsonData")
+ 
+         if (path is not None):
+-            self.logger().warn(f"Initializing persistent storage from file: {path}")
++            LOGGER.info(f"Initializing persistent storage from file: {path}")
+         else:
+-            self.logger().warn("Initializing persistent storage from dict")
++            LOGGER.info("Initializing persistent storage from dict")
+ 
+         self._handle = chip.native.GetLibraryHandle()
+         self._isActive = True
+@@ -125,24 +124,24 @@ class PersistentStorage:
+                 self._file.seek(0)
+ 
+                 if (size != 0):
+-                    self.logger().warn(f"Loading configuration from {path}...")
++                    LOGGER.info(f"Loading configuration from {path}...")
+                     self._jsonData = json.load(self._file)
+                 else:
+                     self._jsonData = {}
+ 
+             except Exception as ex:
+-                logging.error(ex)
+-                logging.critical(f"Could not load configuration from {path} - resetting configuration...")
++                LOGGER.error(ex)
++                LOGGER.critical(f"Could not load configuration from {path} - resetting configuration...")
+                 self._jsonData = {}
+         else:
+             self._jsonData = jsonData
+ 
+         if ('sdk-config' not in self._jsonData):
+-            logging.warn("No valid SDK configuration present - clearing out configuration")
++            LOGGER.warn("No valid SDK configuration present - clearing out configuration")
+             self._jsonData['sdk-config'] = {}
+ 
+         if ('repl-config' not in self._jsonData):
+-            logging.warn("No valid REPL configuration present - clearing out configuration")
++            LOGGER.warn("No valid REPL configuration present - clearing out configuration")
+             self._jsonData['repl-config'] = {}
+ 
+         # Clear out the file so that calling 'Commit' will re-open the file at that time in write mode.
+@@ -166,7 +165,6 @@ class PersistentStorage:
+         ''' Commits the cached JSON configuration to file (if one was provided in the constructor).
+             Otherwise, this is a no-op.
+         '''
+-        self.logger().info("Committing...")
+ 
+         if (self._path is None):
+             return
+@@ -175,9 +173,8 @@ class PersistentStorage:
+             try:
+                 self._file = open(self._path, 'w')
+             except Exception as ex:
+-                logging.warn(
+-                    f"Could not open {self._path} for writing configuration. Error:")
+-                logging.warn(ex)
++                LOGGER.error(
++                    f"Could not open {self._path} for writing configuration. Error: {ex}")
+                 return
+ 
+         self._file.seek(0)
+@@ -188,7 +185,7 @@ class PersistentStorage:
+     def SetReplKey(self, key: str, value):
+         ''' Set a REPL key to a specific value. Creates the key if one doesn't exist already.
+         '''
+-        self.logger().info(f"SetReplKey: {key} = {value}")
++        LOGGER.debug(f"SetReplKey: {key} = {value}")
+ 
+         if (key is None or key == ''):
+             raise ValueError("Invalid Key")
+@@ -212,7 +209,7 @@ class PersistentStorage:
+     def SetSdkKey(self, key: str, value: bytes):
+         ''' Set an SDK key to a specific value. Creates the key if one doesn't exist already.
+         '''
+-        self.logger().info(f"SetSdkKey: {key} = {value}")
++        LOGGER.debug(f"SetSdkKey: {key} = {value}")
+ 
+         if (key is None or key == ''):
+             raise ValueError("Invalid Key")
+@@ -236,7 +233,7 @@ class PersistentStorage:
+     def DeleteSdkKey(self, key: str):
+         ''' Deletes an SDK key if one exists.
+         '''
+-        self.logger().info(f"DeleteSdkKey: {key}")
++        LOGGER.debug(f"DeleteSdkKey: {key}")
+ 
+         del (self._jsonData['sdk-config'][key])
+         self.Commit()
+-- 
+2.45.2
+

--- a/0032-Python-Avoid-RuntimeException-if-APIs-with-future-ra.patch
+++ b/0032-Python-Avoid-RuntimeException-if-APIs-with-future-ra.patch
@@ -1,0 +1,288 @@
+From 93674dd02f8533ef35afa5c61180507e5ff75fe7 Mon Sep 17 00:00:00 2001
+From: Stefan Agner <stefan@agner.ch>
+Date: Wed, 17 Jul 2024 18:26:56 +0100
+Subject: [PATCH] [Python] Avoid RuntimeException if APIs with future raise an
+ error (#34354)
+
+Currently, when calling an API which uses a future causes an error
+(e.g. CommissionWithCode with an invalid code), then the API call
+already returns an error. In this case the call `raise_on_error()` on
+the returned PyChipError object make sure that an exception is raised.
+However, this also causes the `CallbackContext` context manager to
+exit.
+
+At this point the future is initialized but never completed, which
+triggers the previously introduced sanity check in `CallbackContext`:
+`RuntimeError("CallbackContext future not completed")`.
+
+Remove the RuntimeError as existing the context manager early without
+completing the future is a use case (when the call setting up the
+callback raises an exception).
+
+Instead, just cancel the future in the context manager if it hasn't
+been complete yet, in case someone has a reference to it and expects
+it to complete.
+
+Also, since most API calls return PyChipError, this changes
+`CallAsync()` to raise an exception by default instead of returning a
+PyChipError object. If the PyChipError object is required or an API
+returns something else, the CallAsyncWithResult() method can be used.
+---
+ src/controller/python/chip/ChipDeviceCtrl.py  | 49 ++++++++-----------
+ src/controller/python/chip/ChipStack.py       |  7 ++-
+ .../python/chip/clusters/Attribute.py         |  2 +-
+ .../python/chip/clusters/Command.py           |  4 +-
+ 4 files changed, 30 insertions(+), 32 deletions(-)
+
+diff --git a/src/controller/python/chip/ChipDeviceCtrl.py b/src/controller/python/chip/ChipDeviceCtrl.py
+index fc387728ce..3ea996e53c 100644
+--- a/src/controller/python/chip/ChipDeviceCtrl.py
++++ b/src/controller/python/chip/ChipDeviceCtrl.py
+@@ -162,7 +162,10 @@ class CallbackContext:
+ 
+     async def __aexit__(self, exc_type, exc_value, traceback):
+         if not self._future.done():
+-            raise RuntimeError("CallbackContext future not completed")
++            # In case the initial call (which sets up for the callback) fails,
++            # the future will never be used actually. So just cancel it here
++            # for completeness, in case somebody is expecting it to be completed.
++            self._future.cancel()
+         self._future = None
+         self._lock.release()
+ 
+@@ -508,11 +511,10 @@ class ChipDeviceControllerBase():
+ 
+         async with self._commissioning_context as ctx:
+             self._enablePairingCompleteCallback(True)
+-            res = await self._ChipStack.CallAsync(
++            await self._ChipStack.CallAsync(
+                 lambda: self._dmLib.pychip_DeviceController_ConnectBLE(
+                     self.devCtrl, discriminator, isShortDiscriminator, setupPinCode, nodeid)
+             )
+-            res.raise_on_error()
+ 
+             return await asyncio.futures.wrap_future(ctx.future)
+ 
+@@ -520,11 +522,11 @@ class ChipDeviceControllerBase():
+         self.CheckIsActive()
+ 
+         async with self._unpair_device_context as ctx:
+-            res = await self._ChipStack.CallAsync(
++            await self._ChipStack.CallAsync(
+                 lambda: self._dmLib.pychip_DeviceController_UnpairDevice(
+                     self.devCtrl, nodeid, self.cbHandleDeviceUnpairCompleteFunct)
+             )
+-            res.raise_on_error()
++
+             return await asyncio.futures.wrap_future(ctx.future)
+ 
+     def CloseBLEConnection(self):
+@@ -561,8 +563,7 @@ class ChipDeviceControllerBase():
+ 
+         async with self._pase_establishment_context as ctx:
+             self._enablePairingCompleteCallback(True)
+-            res = await self._ChipStack.CallAsync(callFunct)
+-            res.raise_on_error()
++            await self._ChipStack.CallAsync(callFunct)
+             await asyncio.futures.wrap_future(ctx.future)
+ 
+     async def EstablishPASESessionBLE(self, setupPinCode: int, discriminator: int, nodeid: int) -> None:
+@@ -661,13 +662,12 @@ class ChipDeviceControllerBase():
+         # Discovery is also used during commissioning. Make sure this manual discovery
+         # and commissioning attempts do not interfere with each other.
+         async with self._commissioning_lock:
+-            res = await self._ChipStack.CallAsync(
++            await self._ChipStack.CallAsync(
+                 lambda: self._dmLib.pychip_DeviceController_DiscoverCommissionableNodes(
+                     self.devCtrl, int(filterType), str(filter).encode("utf-8")))
+-            res.raise_on_error()
+ 
+             async def _wait_discovery():
+-                while not await self._ChipStack.CallAsync(
++                while not await self._ChipStack.CallAsyncWithResult(
+                         lambda: self._dmLib.pychip_DeviceController_HasDiscoveredCommissionableNode(self.devCtrl)):
+                     await asyncio.sleep(0.1)
+                 return
+@@ -681,9 +681,8 @@ class ChipDeviceControllerBase():
+                 # Expected timeout, do nothing
+                 pass
+             finally:
+-                res = await self._ChipStack.CallAsync(
++                await self._ChipStack.CallAsync(
+                     lambda: self._dmLib.pychip_DeviceController_StopCommissionableDiscovery(self.devCtrl))
+-                res.raise_on_error()
+ 
+             return await self.GetDiscoveredDevices()
+ 
+@@ -701,7 +700,7 @@ class ChipDeviceControllerBase():
+             self._dmLib.pychip_DeviceController_IterateDiscoveredCommissionableNodes(devCtrl.devCtrl, HandleDevice)
+             return devices
+ 
+-        return await self._ChipStack.CallAsync(lambda: GetDevices(self))
++        return await self._ChipStack.CallAsyncWithResult(lambda: GetDevices(self))
+ 
+     def GetIPForDiscoveredDevice(self, idx, addrStr, length):
+         self.CheckIsActive()
+@@ -733,11 +732,10 @@ class ChipDeviceControllerBase():
+         self.CheckIsActive()
+ 
+         async with self._open_window_context as ctx:
+-            res = await self._ChipStack.CallAsync(
++            await self._ChipStack.CallAsync(
+                 lambda: self._dmLib.pychip_DeviceController_OpenCommissioningWindow(
+                     self.devCtrl, self.pairingDelegate, nodeid, timeout, iteration, discriminator, option)
+             )
+-            res.raise_on_error()
+ 
+             return await asyncio.futures.wrap_future(ctx.future)
+ 
+@@ -839,7 +837,7 @@ class ChipDeviceControllerBase():
+ 
+         if allowPASE:
+             returnDevice = c_void_p(None)
+-            res = await self._ChipStack.CallAsync(lambda: self._dmLib.pychip_GetDeviceBeingCommissioned(
++            res = await self._ChipStack.CallAsyncWithResult(lambda: self._dmLib.pychip_GetDeviceBeingCommissioned(
+                 self.devCtrl, nodeid, byref(returnDevice)), timeoutMs)
+             if res.is_success:
+                 LOGGER.info('Using PASE connection')
+@@ -869,10 +867,9 @@ class ChipDeviceControllerBase():
+ 
+         closure = DeviceAvailableClosure(eventLoop, future)
+         ctypes.pythonapi.Py_IncRef(ctypes.py_object(closure))
+-        res = await self._ChipStack.CallAsync(lambda: self._dmLib.pychip_GetConnectedDeviceByNodeId(
++        await self._ChipStack.CallAsync(lambda: self._dmLib.pychip_GetConnectedDeviceByNodeId(
+             self.devCtrl, nodeid, ctypes.py_object(closure), _DeviceAvailableCallback),
+             timeoutMs)
+-        res.raise_on_error()
+ 
+         # The callback might have been received synchronously (during self._ChipStack.CallAsync()).
+         # In that case the Future has already been set it will return immediately
+@@ -1752,11 +1749,10 @@ class ChipDeviceController(ChipDeviceControllerBase):
+ 
+         async with self._commissioning_context as ctx:
+             self._enablePairingCompleteCallback(False)
+-            res = await self._ChipStack.CallAsync(
++            await self._ChipStack.CallAsync(
+                 lambda: self._dmLib.pychip_DeviceController_Commission(
+                     self.devCtrl, nodeid)
+             )
+-            res.raise_on_error()
+ 
+             return await asyncio.futures.wrap_future(ctx.future)
+ 
+@@ -1868,11 +1864,10 @@ class ChipDeviceController(ChipDeviceControllerBase):
+ 
+         async with self._commissioning_context as ctx:
+             self._enablePairingCompleteCallback(True)
+-            res = await self._ChipStack.CallAsync(
++            await self._ChipStack.CallAsync(
+                 lambda: self._dmLib.pychip_DeviceController_OnNetworkCommission(
+                     self.devCtrl, self.pairingDelegate, nodeId, setupPinCode, int(filterType), str(filter).encode("utf-8") if filter is not None else None, discoveryTimeoutMsec)
+             )
+-            res.raise_on_error()
+ 
+             return await asyncio.futures.wrap_future(ctx.future)
+ 
+@@ -1889,11 +1884,10 @@ class ChipDeviceController(ChipDeviceControllerBase):
+ 
+         async with self._commissioning_context as ctx:
+             self._enablePairingCompleteCallback(True)
+-            res = await self._ChipStack.CallAsync(
++            await self._ChipStack.CallAsync(
+                 lambda: self._dmLib.pychip_DeviceController_ConnectWithCode(
+                     self.devCtrl, setupPayload.encode("utf-8"), nodeid, discoveryType.value)
+             )
+-            res.raise_on_error()
+ 
+             return await asyncio.futures.wrap_future(ctx.future)
+ 
+@@ -1909,11 +1903,10 @@ class ChipDeviceController(ChipDeviceControllerBase):
+ 
+         async with self._commissioning_context as ctx:
+             self._enablePairingCompleteCallback(True)
+-            res = await self._ChipStack.CallAsync(
++            await self._ChipStack.CallAsync(
+                 lambda: self._dmLib.pychip_DeviceController_ConnectIP(
+                     self.devCtrl, ipaddr.encode("utf-8"), setupPinCode, nodeid)
+             )
+-            res.raise_on_error()
+ 
+             return await asyncio.futures.wrap_future(ctx.future)
+ 
+@@ -1930,11 +1923,11 @@ class ChipDeviceController(ChipDeviceControllerBase):
+         self.CheckIsActive()
+ 
+         async with self._issue_node_chain_context as ctx:
+-            res = await self._ChipStack.CallAsync(
++            await self._ChipStack.CallAsync(
+                 lambda: self._dmLib.pychip_DeviceController_IssueNOCChain(
+                     self.devCtrl, py_object(self), csr.NOCSRElements, len(csr.NOCSRElements), nodeId)
+             )
+-            res.raise_on_error()
++
+             return await asyncio.futures.wrap_future(ctx.future)
+ 
+ 
+diff --git a/src/controller/python/chip/ChipStack.py b/src/controller/python/chip/ChipStack.py
+index dc4efc223f..b717859c70 100644
+--- a/src/controller/python/chip/ChipStack.py
++++ b/src/controller/python/chip/ChipStack.py
+@@ -216,7 +216,7 @@ class ChipStack(object):
+         '''
+         return self.PostTaskOnChipThread(callFunct).Wait(timeoutMs)
+ 
+-    async def CallAsync(self, callFunct, timeoutMs: int = None):
++    async def CallAsyncWithResult(self, callFunct, timeoutMs: int = None):
+         '''Run a Python function on CHIP stack, and wait for the response.
+         This function will post a task on CHIP mainloop and waits for the call response in a asyncio friendly manner.
+         '''
+@@ -232,6 +232,11 @@ class ChipStack(object):
+ 
+         return await asyncio.wait_for(callObj.future, timeoutMs / 1000 if timeoutMs else None)
+ 
++    async def CallAsync(self, callFunct, timeoutMs: int = None) -> None:
++        '''Run a Python function on CHIP stack, and wait for the response.'''
++        res: PyChipError = await self.CallAsyncWithResult(callFunct, timeoutMs)
++        res.raise_on_error()
++
+     def PostTaskOnChipThread(self, callFunct) -> AsyncCallableHandle:
+         '''Run a Python function on CHIP stack, and wait for the response.
+         This function will post a task on CHIP mainloop, and return an object with Wait() method for getting the result.
+diff --git a/src/controller/python/chip/clusters/Attribute.py b/src/controller/python/chip/clusters/Attribute.py
+index 69c64a3ffc..31e8444c70 100644
+--- a/src/controller/python/chip/clusters/Attribute.py
++++ b/src/controller/python/chip/clusters/Attribute.py
+@@ -482,7 +482,7 @@ class SubscriptionTransaction:
+ 
+     async def TriggerResubscribeIfScheduled(self, reason: str):
+         handle = chip.native.GetLibraryHandle()
+-        await builtins.chipStack.CallAsync(
++        await builtins.chipStack.CallAsyncWithResult(
+             lambda: handle.pychip_ReadClient_TriggerResubscribeIfScheduled(
+                 self._readTransaction._pReadClient, reason.encode("utf-8"))
+         )
+diff --git a/src/controller/python/chip/clusters/Command.py b/src/controller/python/chip/clusters/Command.py
+index 93951338f9..785bb3d3da 100644
+--- a/src/controller/python/chip/clusters/Command.py
++++ b/src/controller/python/chip/clusters/Command.py
+@@ -316,7 +316,7 @@ async def SendCommand(future: Future, eventLoop, responseType: Type, device, com
+ 
+     payloadTLV = payload.ToTLV()
+     ctypes.pythonapi.Py_IncRef(ctypes.py_object(transaction))
+-    return await builtins.chipStack.CallAsync(
++    return await builtins.chipStack.CallAsyncWithResult(
+         lambda: handle.pychip_CommandSender_SendCommand(
+             ctypes.py_object(transaction), device,
+             c_uint16(0 if timedRequestTimeoutMs is None else timedRequestTimeoutMs), commandPath.EndpointId,
+@@ -388,7 +388,7 @@ async def SendBatchCommands(future: Future, eventLoop, device, commands: List[In
+     transaction = AsyncBatchCommandsTransaction(future, eventLoop, responseTypes)
+     ctypes.pythonapi.Py_IncRef(ctypes.py_object(transaction))
+ 
+-    return await builtins.chipStack.CallAsync(
++    return await builtins.chipStack.CallAsyncWithResult(
+         lambda: handle.pychip_CommandSender_SendBatchCommands(
+             py_object(transaction), device,
+             c_uint16(0 if timedRequestTimeoutMs is None else timedRequestTimeoutMs),
+-- 
+2.45.2
+

--- a/0033-Python-Fix-build-without-host-unit-test-config-34368.patch
+++ b/0033-Python-Fix-build-without-host-unit-test-config-34368.patch
@@ -1,0 +1,72 @@
+From 7210d2ded0bcf5c5989cef8af34f84828116ada3 Mon Sep 17 00:00:00 2001
+From: Stefan Agner <stefan@agner.ch>
+Date: Wed, 17 Jul 2024 19:10:18 +0100
+Subject: [PATCH] [Python] Fix build without host unit test config (#34368)
+
+Allow to build the Python controller without host unit test config
+enabled.
+---
+ src/controller/python/chip/clusters/command.cpp | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/src/controller/python/chip/clusters/command.cpp b/src/controller/python/chip/clusters/command.cpp
+index d65766b798..037c848f96 100644
+--- a/src/controller/python/chip/clusters/command.cpp
++++ b/src/controller/python/chip/clusters/command.cpp
+@@ -203,10 +203,13 @@ PyChipError SendBatchCommandsInternal(void * appContext, DeviceProxy * device, u
+     CHIP_ERROR err = CHIP_NO_ERROR;
+ 
+     bool testOnlySuppressTimedRequestMessage = false;
+-    uint16_t * testOnlyCommandRefsOverride   = nullptr;
++#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
++    uint16_t * testOnlyCommandRefsOverride = nullptr;
++#endif
+ 
+     VerifyOrReturnError(device->GetSecureSession().HasValue(), ToPyChipError(CHIP_ERROR_MISSING_SECURE_SESSION));
+ 
++#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+     // Test only override validation checks and setup
+     if (testOnlyOverrides != nullptr)
+     {
+@@ -228,6 +231,7 @@ PyChipError SendBatchCommandsInternal(void * appContext, DeviceProxy * device, u
+         config.SetRemoteMaxPathsPerInvoke(testOnlyOverrides->overrideRemoteMaxPathsPerInvoke);
+     }
+     else
++#endif
+     {
+         auto remoteSessionParameters = device->GetSecureSession().Value()->GetRemoteSessionParameters();
+         config.SetRemoteMaxPathsPerInvoke(remoteSessionParameters.GetMaxPathsPerInvoke());
+@@ -273,6 +277,7 @@ PyChipError SendBatchCommandsInternal(void * appContext, DeviceProxy * device, u
+         Optional<uint16_t> timedRequestTimeout =
+             timedRequestTimeoutMs != 0 ? Optional<uint16_t>(timedRequestTimeoutMs) : Optional<uint16_t>::Missing();
+         CommandSender::FinishCommandParameters finishCommandParams(timedRequestTimeout);
++#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+         if (testOnlyCommandRefsOverride != nullptr)
+         {
+             finishCommandParams.commandRef.SetValue(testOnlyCommandRefsOverride[i]);
+@@ -291,6 +296,7 @@ PyChipError SendBatchCommandsInternal(void * appContext, DeviceProxy * device, u
+             callback->AddCommandRefToIndexLookup(finishCommandParams.commandRef.Value(), i);
+         }
+         else
++#endif
+         {
+             SuccessOrExit(err = callback->AddCommandRefToIndexLookup(finishCommandParams.commandRef.Value(), i));
+         }
+@@ -300,12 +306,14 @@ PyChipError SendBatchCommandsInternal(void * appContext, DeviceProxy * device, u
+         Optional<System::Clock::Timeout> interactionTimeout = interactionTimeoutMs != 0
+             ? MakeOptional(System::Clock::Milliseconds32(interactionTimeoutMs))
+             : Optional<System::Clock::Timeout>::Missing();
++#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+         if (testOnlySuppressTimedRequestMessage)
+         {
+             SuccessOrExit(err = sender->TestOnlyCommandSenderTimedRequestFlagWithNoTimedInvoke(device->GetSecureSession().Value(),
+                                                                                                interactionTimeout));
+         }
+         else
++#endif
+         {
+             SuccessOrExit(err = sender->SendCommandRequest(device->GetSecureSession().Value(), interactionTimeout));
+         }
+-- 
+2.45.2
+

--- a/CHIPProjectConfig.h
+++ b/CHIPProjectConfig.h
@@ -54,7 +54,7 @@
 
 #define CHIP_CONFIG_DATA_MANAGEMENT_CLIENT_EXPERIMENTAL 1
 
-#define CONFIG_BUILD_FOR_HOST_UNIT_TEST 1
+#define CONFIG_BUILD_FOR_HOST_UNIT_TEST 0
 
 // Home Assistant Python Matter server specific configs
 #define CHIP_EXCHANGE_NODE_ID_LOGGING 1


### PR DESCRIPTION
By default the Python controller gets built with unit test configuration enabled. This adds extra functionality to inject errors etc. for testing. There is no known negative effect to have it enabled, but it is certainly better to disable it for a production setup.

Furthermore this fixes error handling for APIs with callbacks and improves logging somewhat.

Specifically, this integrates changes from the following PRs
- https://github.com/project-chip/connectedhomeip/pull/34346
- https://github.com/project-chip/connectedhomeip/pull/34354
- https://github.com/project-chip/connectedhomeip/pull/34368