### PR TITLE
apt install -y zstd need confirm to install (build.yaml)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -105,7 +105,7 @@ jobs:
       - name: Extract Matter SDK from tar
         working-directory: ./
         run: |
-          apt update && apt install zstd
+          apt update && apt install -y zstd
           rm -rf connectedhomeip/
           tar -xaf ./connectedhomeip.tar.zst --use-compress-program=zstdmt .
           git config --global --add safe.directory "*"


### PR DESCRIPTION
`apt install -y zstd` need confirm to install according to this CI job:
 - https://github.com/home-assistant-libs/chip-wheels/actions/runs/11918359604/job/33216046662?pr=100

```
Run apt update && apt install zstd

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Get:1 http://security.ubuntu.com/ubuntu noble-security InRelease [126 kB]
Get:2 http://archive.ubuntu.com/ubuntu noble InRelease [256 kB]
Get:3 http://security.ubuntu.com/ubuntu noble-security/main amd64 Packages [617 kB]
Get:4 http://archive.ubuntu.com/ubuntu noble-updates InRelease [126 kB]
Get:5 http://archive.ubuntu.com/ubuntu noble-backports InRelease [126 kB]
Get:6 http://security.ubuntu.com/ubuntu noble-security/multiverse amd64 Packages [15.3 kB]
Get:7 http://security.ubuntu.com/ubuntu noble-security/universe amd64 Packages [725 kB]
Get:8 http://archive.ubuntu.com/ubuntu noble/multiverse amd64 Packages [331 kB]
Get:9 http://security.ubuntu.com/ubuntu noble-security/restricted amd64 Packages [598 kB]
Get:10 http://archive.ubuntu.com/ubuntu noble/universe amd64 Packages [19.3 MB]
Get:11 http://archive.ubuntu.com/ubuntu noble/restricted amd64 Packages [117 kB]
Get:12 http://archive.ubuntu.com/ubuntu noble/main amd64 Packages [1808 kB]
Get:13 http://archive.ubuntu.com/ubuntu noble-updates/multiverse amd64 Packages [18.4 kB]
Get:14 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 Packages [843 kB]
Get:15 http://archive.ubuntu.com/ubuntu noble-updates/restricted amd64 Packages [598 kB]
Get:16 http://archive.ubuntu.com/ubuntu noble-updates/universe amd64 Packages [932 kB]
Get:17 http://archive.ubuntu.com/ubuntu noble-backports/universe amd64 Packages [11.8 kB]
Fetched 26.6 MB in 4s (7220 kB/s)
Reading package lists...
Building dependency tree...
Reading state information...
153 packages can be upgraded. Run 'apt list --upgradable' to see them.

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  libzstd1
The following NEW packages will be installed:
  zstd
The following packages will be upgraded:
  libzstd1
1 upgraded, 1 newly installed, 0 to remove and 152 not upgraded.
Need to get 943 kB of archives.
After this operation, 1845 kB of additional disk space will be used.
Do you want to continue? [Y/n] Abort.
Error: Process completed with exit code 1.
```