### PR TITLE
Use build container from base branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -106,6 +106,9 @@ jobs:
               if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -E '^Dockerfile'; then
                 echo "Dockerfile or related files changed; building container."
                 build_needed=true
+              else
+                echo "No changes to Dockerfile; using container from base branch."
+                tag="${{ github.base_ref }}"
               fi
             fi
           fi


### PR DESCRIPTION
If there have been no changes to the build container, make sure to use the container from the base branch. This fixes builds for PRs which don't touch the build containers Dockerfile.