### PR TITLE
Explicitly select new data model provider

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -199,6 +199,7 @@ jobs:
                                           chip_exchange_node_id_logging=true \
                                           chip_mdns=\"minimal\" \
                                           chip_minmdns_default_policy=\"libnl\" \
+                                          chip_use_data_model_interface=\"enabled\" \
                                           chip_python_version=\"${{ needs.build_prepare.outputs.version }}\"  \
                                           chip_python_package_prefix=\"home-assistant-chip\" \
                                           chip_python_platform_tag=\"manylinux_2_31\" \


### PR DESCRIPTION
Matter v1.4 brings a new interaction model implementation. Use it by default. Note that the master branch already dropped that setting again, since the old Ember interaction model got removed from the code base. So this change is only necessary for the release branch.